### PR TITLE
Adición del archivo contributors.txt a la rama main

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -1,0 +1,5 @@
+NAME - Public Github repo
+
+Roger Torrent - https://github.com/R-Torrent
+
+Suren Davidiants - https://github.com/surdav


### PR DESCRIPTION
He añadido mi nombre y github al archivo contributors.txt. Este archivo no estaba en la rama principal main, pues la añado con este pr.