### PR TITLE
BABCN-34 (eliminar println y printStackTrace)

### DIFF
--- a/BusinessAssistant-login/src/main/java/com/businessassistantbcn/login/config/LoggerConfig.java
+++ b/BusinessAssistant-login/src/main/java/com/businessassistantbcn/login/config/LoggerConfig.java
@@ -1,5 +1,8 @@
 package com.businessassistantbcn.login.config;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
@@ -8,5 +11,12 @@ import org.springframework.context.annotation.Configuration;
 public class LoggerConfig {
 	
 	public static final Logger log = LoggerFactory.getLogger(LoggerConfig.class);
+	
+	public static void logStackTrace(Exception e) {
+		StringWriter sw = new StringWriter();
+		PrintWriter pw = new PrintWriter(sw);
+		e.printStackTrace(pw);
+		log.error(sw.toString());
+	}
 	
 }

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/config/LoggerConfig.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/config/LoggerConfig.java
@@ -1,5 +1,8 @@
 package com.businessassistantbcn.opendata.config;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
@@ -8,5 +11,12 @@ import org.springframework.context.annotation.Configuration;
 public class LoggerConfig {
 	
 	public static final Logger log = LoggerFactory.getLogger(LoggerConfig.class);
+	
+	public static void logStackTrace(Exception e) {
+		StringWriter sw = new StringWriter();
+		PrintWriter pw = new PrintWriter(sw);
+		e.printStackTrace(pw);
+		log.error(sw.toString());
+	}
 	
 }

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/helper/JsonHelper.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/helper/JsonHelper.java
@@ -6,6 +6,7 @@ import java.util.List;
 import net.bytebuddy.implementation.bytecode.Throw;
 import org.springframework.stereotype.Component;
 
+import com.businessassistantbcn.opendata.config.LoggerConfig;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,8 +27,8 @@ public class JsonHelper<T> {
 		try {
 			list = (List<T>) mapper.readTree(json);
 		} catch (JsonProcessingException e) {
-			System.out.println("No se puede convertir de String a una Lista Generica porque: " + e.getMessage());
-			e.printStackTrace();
+			LoggerConfig.log.error("No se puede convertir de String a una Lista Generica porque: {}", e.getMessage());
+			LoggerConfig.logStackTrace(e);
 		}
 		return list;
 	}
@@ -37,8 +38,8 @@ public class JsonHelper<T> {
 		try {
 			jsonNode = mapper.readTree(json);
 		} catch (JsonProcessingException e) {
-			System.out.println("No se puede convertir de String to JsonNode porque: " + e.getMessage());
-			e.printStackTrace();
+			LoggerConfig.log.error("No se puede convertir de String to JsonNode porque: {}", e.getMessage());
+			LoggerConfig.logStackTrace(e);
 		}
 		return jsonNode;
 	}
@@ -48,8 +49,8 @@ public class JsonHelper<T> {
 		try {
 			jsonString = mapper.writeValueAsString(node);
 		} catch (JsonProcessingException e) {
-			System.out.println("No se puede convertir de JsonNode to String porque: " + e.getMessage());
-			e.printStackTrace();
+			LoggerConfig.log.error("No se puede convertir de JsonNode to String porque: {}", e.getMessage());
+			LoggerConfig.logStackTrace(e);
 		}
 		return jsonString;
 	}
@@ -79,4 +80,5 @@ public class JsonHelper<T> {
 
 		return filteredDto;
 	}
+	
 }


### PR DESCRIPTION
Sólo encontré 3 usos de System.out.println y printStackTrace en todo el código, en sendos métodos de la clase JsonHelper (opendata).