### PR TITLE
BABCN-32 OpendataControllerTest

### DIFF
--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/bigmalls/BigMallsDto.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/bigmalls/BigMallsDto.java
@@ -1,99 +1,96 @@
 package com.businessassistantbcn.opendata.dto.bigmalls;
 
-
 import com.fasterxml.jackson.annotation.JacksonAnnotation;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 @Component
 //@JsonIgnoreProperties({"tickets_data","entity_types_data","attribute_categories", "values","from_relationships", "to_relationships",
  //       "classifications_data","secondary_filters_data","timetable","image_data","gallery_data","warnings","sections_data"})
 public class BigMallsDto {
-
+	
     @JsonProperty("register_id")
-    private long register_id;
+    public long register_id;
     @JsonProperty("prefix")
-    private String prefix;
+    public String prefix;
     @JsonProperty("suffix")
-    private String suffix;
+    public String suffix;
     @JsonProperty("name")
-    private String name;
+    public String name;
     @JsonProperty("created")
-    private String created;
+    public String created;
     @JsonProperty("modified")
-    private String modified;
+    public String modified;
     @JsonProperty("status")
-    private String status;
+    public String status;
     @JsonProperty("status_name")
-    private String status_name;
+    public String status_name;
     @JsonProperty("core_type")
-    private String core_type;
+    public String core_type;
     @JsonProperty("core_type_name")
-    private String core_type_name;
+    public String core_type_name;
     @JsonProperty("body")
-    private String body;
+    public String body;
     @JsonProperty("tickets_data")
-    private List<Object> tickets_data;
-    //prueba con objetos object directamente
+    public List<Object> tickets_data;
     @JsonProperty("addresses")
-    private List<Object> addresses;
+    public List<Object> addresses;
     @JsonProperty("entity_types_data")
-    private List<Object> entity_types_data;
+    public List<Object> entity_types_data;
     @JsonProperty("attribute_categories")
-    private List<Object> attribute_categories;
+    public List<Object> attribute_categories;
     @JsonProperty("values")
-    private List<Object> values;
+    public List<Object> values;
     @JsonProperty("from_relationships")
-    private List<Object> from_relationships;
+    public List<Object> from_relationships;
     @JsonProperty("to_relationships")
-    private List<Object> to_relationships;
+    public List<Object> to_relationships;
     @JsonProperty("classifications_data")
-    private List<Object> classifications_data;
+    public List<Object> classifications_data;
     @JsonProperty("secondary_filters_data")
-    private List<Object> secondary_filters_data;
+    public List<Object> secondary_filters_data;
     @JsonProperty("timetable")
-    private Object timetable;
+    public Object timetable;
     @JsonProperty("image_data")
-    private Object image_data;
+    public Object image_data;
     @JsonProperty("gallery_data")
-    private List<Object> gallery_data;
+    public List<Object> gallery_data;
     @JsonProperty("warnings")
-    private List<Object> warnings;
+    public List<Object> warnings;
     @JsonProperty("geo_epgs_25831")
-    private CoordinateDto geo_epgs_25831;
+    public CoordinateDto geo_epgs_25831;
     @JsonProperty("geo_epgs_23031")
-    private CoordinateDto geo_epgs_23031;
+    public CoordinateDto geo_epgs_23031;
     @JsonProperty("geo_epgs_4326")
-    private CoordinateDto geo_epgs_4326;
+    public CoordinateDto geo_epgs_4326;
     @JsonProperty("is_section_of_data")
-    private boolean is_section_of_data;
+    public boolean is_section_of_data;
     @JsonProperty("sections_data")
-    private List<Object> sections_data;
+    public List<Object> sections_data;
     @JsonProperty("start_date")
-    private String start_date;
+    public String start_date;
     @JsonProperty("end_date")
-    private String end_date;
+    public String end_date;
     @JsonProperty("estimated_dates")
-    private String estimated_dates;
+    public String estimated_dates;
     @JsonProperty("languages_data")
-    private String languages_data;
+    public String languages_data;
     @JsonProperty("type")
-    private String type;
+    public String type;
     @JsonProperty("type_name")
-    private String type_name;
+    public String type_name;
     @JsonProperty("period")
-    private String period;
+    public String period;
     @JsonProperty("period_name")
-    private String period_name;
+    public String period_name;
     @JsonProperty("event_status_name")
-    private String event_status_name;
+    public String event_status_name;
     @JsonProperty("event_status")
-    private String event_status;
+    public String event_status;
     @JsonProperty("ical")
-    private String ical;
-
-
+    public String ical;
+    
 }

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/bigmalls/CoordinateDto.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/bigmalls/CoordinateDto.java
@@ -4,16 +4,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class CoordinateDto {
 	
-    @JsonProperty("x")
-    public double x;
-    @JsonProperty("y")
-    public double y;
-    
-    public CoordinateDto() {}
-    
-    public CoordinateDto(double x, double y) {
-    	this.x = x;
-    	this.y = y;
+	@JsonProperty("x")
+	public double x;
+	@JsonProperty("y")
+	public double y;
+	
+	public CoordinateDto() {}
+	
+	public CoordinateDto(double x, double y) {
+		this.x = x;
+		this.y = y;
     }
     
 }

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/bigmalls/CoordinateDto.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/bigmalls/CoordinateDto.java
@@ -3,8 +3,17 @@ package com.businessassistantbcn.opendata.dto.bigmalls;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class CoordinateDto {
+	
     @JsonProperty("x")
-    float x;
+    public double x;
     @JsonProperty("y")
-    float y;
+    public double y;
+    
+    public CoordinateDto() {}
+    
+    public CoordinateDto(double x, double y) {
+    	this.x = x;
+    	this.y = y;
+    }
+    
 }

--- a/BusinessAssistant-opendata/src/test/java/com/businessassistantbcn/opendata/controller/OpendataControllerTest.java
+++ b/BusinessAssistant-opendata/src/test/java/com/businessassistantbcn/opendata/controller/OpendataControllerTest.java
@@ -41,210 +41,212 @@ import static org.hamcrest.Matchers.equalTo;
 @WebFluxTest(controllers = OpendataController.class)
 public class OpendataControllerTest {
 	
-    @Autowired
-    private WebTestClient webTestClient;
-    
-    private final String
-    	CONTROLLER_BASE_URL = "/v1/api/opendata",
-    	RES0 = "$.results[0].";
-    
-    @MockBean
-    private BigMallsService bigMallsService;
-    @MockBean
-    private TestService testService;
-    @MockBean
-    private EconomicActivitiesCensusService economicActivitiesCensusService;
-    @MockBean
-    private CommercialGalleriesService commercialGalleriesService;
-    @MockBean
-    private LargeStablishmentsService largeStablishmentsService;
-    @MockBean
-    private MarketFairsService marketFairsService;
-    @MockBean
-    private DataConfigService bcnZonesService;
-    
-    @DisplayName("Simple String response")
-    @Test
-    public void testHello(){
-        final String URI_TEST = "/test";
-        
-        webTestClient.get()
-                .uri(CONTROLLER_BASE_URL + URI_TEST)
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody(String.class)
-                .value(s -> s.toString(), equalTo("Hello from BusinessAssistant Barcelona!!!"));
-    }
-    
-    @DisplayName("Reactive response -- Star Wars vehicles")
-    @Test
-    public void testReactive() { try {
-    	
-    	final String URI_TEST = "/test-reactive";
-    	
-    	StarWarsVehicleDto vehicleSW = new StarWarsVehicleDto();
-    	vehicleSW.name = "R18 GTD (familiar)";
-    	vehicleSW.model = "Renault 18 GTD";
-    	vehicleSW.manufacturer = "Renault";
-    	vehicleSW.length = 4.487F;
-    	vehicleSW.max_atmosphering_speed = 156;
-    	vehicleSW.crew = 1;
-    	vehicleSW.passengers = 4;
-    	
-    	StarWarsVehiclesResultDto vehiclesResultSW = new StarWarsVehiclesResultDto();
-    	vehiclesResultSW.setCount(1);
-    	vehiclesResultSW.setNext(null);
-    	vehiclesResultSW.setPrevious(null);
-    	vehiclesResultSW.setResults(new StarWarsVehicleDto[]{vehicleSW});
-    	
-    	Mockito
+	@Autowired
+	private WebTestClient webTestClient;
+	
+	private final String
+		CONTROLLER_BASE_URL = "/v1/api/opendata",
+		RES0 = "$.results[0].";
+	
+	@MockBean
+	private BigMallsService bigMallsService;
+	@MockBean
+	private TestService testService;
+	@MockBean
+	private EconomicActivitiesCensusService economicActivitiesCensusService;
+	@MockBean
+	private CommercialGalleriesService commercialGalleriesService;
+	@MockBean
+	private LargeStablishmentsService largeStablishmentsService;
+	@MockBean
+	private MarketFairsService marketFairsService;
+	@MockBean
+	private DataConfigService bcnZonesService;
+	
+	@DisplayName("Simple String response")
+	@Test
+	public void testHello(){
+		
+		final String URI_TEST = "/test";
+		
+		webTestClient.get()
+				.uri(CONTROLLER_BASE_URL + URI_TEST)
+				.accept(MediaType.APPLICATION_JSON)
+				.exchange()
+				.expectStatus().isOk()
+				.expectBody(String.class)
+				.value(s -> s.toString(), equalTo("Hello from BusinessAssistant Barcelona!!!"));
+		
+	}
+	
+	@DisplayName("Reactive response -- Star Wars vehicles")
+	@Test
+	public void testReactive() { try {
+		
+		final String URI_TEST = "/test-reactive";
+		
+		StarWarsVehicleDto vehicleSW = new StarWarsVehicleDto();
+		vehicleSW.name = "R18 GTD (familiar)";
+		vehicleSW.model = "Renault 18 GTD";
+		vehicleSW.manufacturer = "Renault";
+		vehicleSW.length = 4.487F;
+		vehicleSW.max_atmosphering_speed = 156;
+		vehicleSW.crew = 1;
+		vehicleSW.passengers = 4;
+		
+		StarWarsVehiclesResultDto vehiclesResultSW = new StarWarsVehiclesResultDto();
+		vehiclesResultSW.setCount(1);
+		vehiclesResultSW.setNext(null);
+		vehiclesResultSW.setPrevious(null);
+		vehiclesResultSW.setResults(new StarWarsVehicleDto[]{vehicleSW});
+		
+		Mockito
 			.when(testService.getTestData())
 			.thenReturn(Mono.just(vehiclesResultSW));
-    	
-    	webTestClient.get()
-    			.uri(CONTROLLER_BASE_URL + URI_TEST)
-    			.accept(MediaType.APPLICATION_JSON)
-    			.exchange()
-    			.expectStatus().isOk()
-    			.expectHeader().contentType(MediaType.APPLICATION_JSON)
+		
+		webTestClient.get()
+				.uri(CONTROLLER_BASE_URL + URI_TEST)
+				.accept(MediaType.APPLICATION_JSON)
+				.exchange()
+				.expectStatus().isOk()
+				.expectHeader().contentType(MediaType.APPLICATION_JSON)
 				.expectBody()
 				.jsonPath("$.count").isEqualTo(1)
 				.jsonPath(RES0 + "name").isNotEmpty()
-    			.jsonPath(RES0 + "name").isEqualTo("R18 GTD (familiar)")
-    			.jsonPath(RES0 + "model").isNotEmpty()
-    			.jsonPath(RES0 + "model").isEqualTo("Renault 18 GTD")
-    			.jsonPath(RES0 + "manufacturer").isNotEmpty()
-    			.jsonPath(RES0 + "manufacturer").isEqualTo("Renault")
-    			.jsonPath(RES0 + "length").isEqualTo(4.487F)
-    			.jsonPath(RES0 + "max_atmosphering_speed").isEqualTo(156)
-    			.jsonPath(RES0 + "crew").isEqualTo(1)
-    			.jsonPath(RES0 + "passengers").isEqualTo(4);
-    	
-    	// Verifica la llamada al método 'getTestData()'.
-    	Mockito.verify(testService).getTestData();
-    	
-    } catch (MalformedURLException e) {
+				.jsonPath(RES0 + "name").isEqualTo("R18 GTD (familiar)")
+				.jsonPath(RES0 + "model").isNotEmpty()
+				.jsonPath(RES0 + "model").isEqualTo("Renault 18 GTD")
+				.jsonPath(RES0 + "manufacturer").isNotEmpty()
+				.jsonPath(RES0 + "manufacturer").isEqualTo("Renault")
+				.jsonPath(RES0 + "length").isEqualTo(4.487F)
+				.jsonPath(RES0 + "max_atmosphering_speed").isEqualTo(156)
+				.jsonPath(RES0 + "crew").isEqualTo(1)
+				.jsonPath(RES0 + "passengers").isEqualTo(4);
+		
+		// Verifica la llamada al método 'getTestData()'.
+		Mockito.verify(testService).getTestData();
+		
+	} catch (MalformedURLException e) {
 		throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Resource not found", e);
 	} }
-    
-    @DisplayName("Opendata response -- JSON elements of commercial centers")
-    @ParameterizedTest(name = "{index} -> URL=''{0}''")
-    @MethodSource("argsProvider")
-    public <T> void JsonResponseTests1(String URI_TEST, Class<T> dtoClass, String stringDtoService) { try {
-    	
-    	// Crear un DTO genérico…
-    	Constructor<T> constructor = dtoClass.getConstructor();		
-    	T genericDTO = constructor.newInstance();
-    	
-    	Field
-    		fld_1 = dtoClass.getDeclaredField("register_id"),
-    		fld_2 = dtoClass.getDeclaredField("name"),
-    		fld_3 = dtoClass.getDeclaredField("created"),
-    		fld_4 = dtoClass.getDeclaredField("geo_epgs_4326");
-    	
-    	// y rellenar sus campos con valores.
-    	fld_1.setLong(genericDTO, 007L);	// Afortunadamente, el número también es válido en octal.
-    	fld_2.set(genericDTO, "Secret Intelligent Service MI6");
-    	fld_3.set(genericDTO, "1909-07-04T00:00:00+00:00");
-    	fld_4.set(genericDTO, new CoordinateDto(51.487222, -0.124167));
-    	
-    	// Crear el empaquetamiento para el DTO anterior…
-    	GenericResultDto<T> genericResultDTO = new GenericResultDto<>();
-    	genericResultDTO.setCount(1);
-    	genericResultDTO.setOffset(0);
-    	genericResultDTO.setLimit(1);
-    	
-    	// y guardarlo dentro.
-    	@SuppressWarnings("unchecked")
+	
+	@DisplayName("Opendata response -- JSON elements of commercial centers")
+	@ParameterizedTest(name = "{index} -> URL=''{0}''")
+	@MethodSource("argsProvider")
+	public <T> void JsonResponseTests1(String URI_TEST, Class<T> dtoClass, String stringDtoService) { try {
+		
+		// Crear un DTO genérico…
+		Constructor<T> constructor = dtoClass.getConstructor();		
+		T genericDTO = constructor.newInstance();
+		
+		Field
+			fld_1 = dtoClass.getDeclaredField("register_id"),
+			fld_2 = dtoClass.getDeclaredField("name"),
+			fld_3 = dtoClass.getDeclaredField("created"),
+			fld_4 = dtoClass.getDeclaredField("geo_epgs_4326");
+		
+		// y rellenar sus campos con valores.
+		fld_1.setLong(genericDTO, 007L);	// Afortunadamente, el número también es válido en octal.
+		fld_2.set(genericDTO, "Secret Intelligent Service MI6");
+		fld_3.set(genericDTO, "1909-07-04T00:00:00+00:00");
+		fld_4.set(genericDTO, new CoordinateDto(51.487222, -0.124167));
+		
+		// Crear el empaquetamiento para el DTO anterior…
+		GenericResultDto<T> genericResultDTO = new GenericResultDto<>();
+		genericResultDTO.setCount(1);
+		genericResultDTO.setOffset(0);
+		genericResultDTO.setLimit(1);
+		
+		// y guardarlo dentro.
+		@SuppressWarnings("unchecked")
 		T[] results = (T[])Array.newInstance(dtoClass, 1);
-    	results[0] = genericDTO;
-    	genericResultDTO.setResults(results);
-    	
-    	// Servicio DTO particular.
-    	Field dtoServiceField = this.getClass().getDeclaredField(stringDtoService);
-    	Object dtoService = dtoServiceField.get(this);
-    	
-    	// Método '.getPage(int,int)' dentro del servicio particular.
-    	Method getPage0m1 = dtoServiceField.getType().getDeclaredMethod("getPage", Integer.TYPE, Integer.TYPE);
-    	
-    	// Intercepta la petición de ensayo, devolviendo un 'Mono' con el 'GenericResultDto<genericDto>'
-    	// de un solo resultado fabricado anteriormente. 
-    	Mockito
+		results[0] = genericDTO;
+		genericResultDTO.setResults(results);
+		
+		// Servicio DTO particular.
+		Field dtoServiceField = this.getClass().getDeclaredField(stringDtoService);
+		Object dtoService = dtoServiceField.get(this);
+		
+		// Método '.getPage(int,int)' dentro del servicio particular.
+		Method getPage0m1 = dtoServiceField.getType().getDeclaredMethod("getPage", Integer.TYPE, Integer.TYPE);
+		
+		// Intercepta la petición de ensayo, devolviendo un 'Mono' con el 'GenericResultDto<genericDto>'
+		// de un solo resultado fabricado anteriormente. 
+		Mockito
 			.when(getPage0m1.invoke(dtoService, 0, -1))
 			.thenReturn(Mono.just(genericResultDTO));
-    	
-    	// Petición de prueba a la página web solicitando datos concretos; parámetros 'offset' y 'limit' sin
-    	// especificar -> equivalente a solicitar todos los resultados. Batería de ensayos sobre el objeto
-    	// JSON "retornado".
-    	webTestClient.get()
-    			.uri(uriBuilder -> uriBuilder.path(CONTROLLER_BASE_URL + URI_TEST)
-//    					.queryParam("offset", 0)
+		
+		// Petición de prueba a la página web solicitando datos concretos; parámetros 'offset' y 'limit' sin
+		// especificar -> equivalente a solicitar todos los resultados. Batería de ensayos sobre el objeto
+		// JSON "retornado".
+		webTestClient.get()
+				.uri(uriBuilder -> uriBuilder.path(CONTROLLER_BASE_URL + URI_TEST)
+//						.queryParam("offset", 0)
 //						.queryParam("limit", -1)
-    					.build())
-    			.accept(MediaType.APPLICATION_JSON)
-    			.exchange()
-    			.expectStatus().isOk()
-    			.expectHeader().contentType(MediaType.APPLICATION_JSON)
-    			.expectBody()
-    			.jsonPath("$.count").isEqualTo(1)
-    			.jsonPath("$.offset").isEqualTo(0)
-    			.jsonPath("$.limit").isEqualTo(1)
-    			.jsonPath(RES0 + "register_id").isEqualTo(007L)
-    			.jsonPath(RES0 + "name").isNotEmpty()
-    			.jsonPath(RES0 + "name").isEqualTo("Secret Intelligent Service MI6")
-    			.jsonPath(RES0 + "created").isNotEmpty()
-    			.jsonPath(RES0 + "created").isEqualTo("1909-07-04T00:00:00+00:00")
-    			.jsonPath(RES0 + "geo_epgs_4326.x").isEqualTo(51.487222)
-    			.jsonPath(RES0 + "geo_epgs_4326.y").isEqualTo(-0.124167);
-    	
-    	// Verificación de la llamada única al método 'getPage(0,-1)' del servicio
-    	getPage0m1.invoke(Mockito.verify(dtoService), 0, -1);
-    	
-    } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException |
-    		IllegalArgumentException | InvocationTargetException | NoSuchFieldException e) {
-    	
-    	throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Failed to return a DTO", e);
-    	
-    } }
-    
-    // Generador de argumentos para los ensayos del controlador con los centros económicos
-    private static Arguments[] argsProvider() {
-    	
-    	final Arguments[] args = {
-    		Arguments.of("/big-malls", BigMallsDto.class, "bigMallsService"),
-//    		Arguments.of("/market-fairs", MarketFairsDto.class, "marketFairsService"),
-//    		Arguments.of("/large-establishments", LargeStablishmentsDto.class, "largeStablishmentsService"),
-//    		Arguments.of("/commercial-galleries", CommercialGalleries.class, "commercialGalleriesService")
-    	};
-    	
-    	return args;
-    	
-    }
-    
-    @DisplayName("Opendata response -- JSON elements of economic activity codes")
-    @Test
-    public void JsonResponseTests2() {
-    	
-    	final String URI_TEST = "/economic-activities-census";
-    	
-    	EconomicActivitiesCensusDto activitatEconomica = new EconomicActivitiesCensusDto();
-    	activitatEconomica.Codi_Activitat_2016 = "314159265";
-    	activitatEconomica.Codi_Activitat_2019 = "057721566";
-    	activitatEconomica.Nom_Activitat = "Exercicis d'apnea";
-    	activitatEconomica.Nom_Sector_Activitat = "Flamenco dancing";
-    	
-    	GenericResultDto<EconomicActivitiesCensusDto> genericResultDTO = new GenericResultDto<>();
-    	genericResultDTO.setCount(1);
-    	genericResultDTO.setOffset(0);
-    	genericResultDTO.setLimit(1);
-    	genericResultDTO.setResults(new EconomicActivitiesCensusDto[]{activitatEconomica});
-    	
-    	Mockito
+						.build())
+				.accept(MediaType.APPLICATION_JSON)
+				.exchange()
+				.expectStatus().isOk()
+				.expectHeader().contentType(MediaType.APPLICATION_JSON)
+				.expectBody()
+				.jsonPath("$.count").isEqualTo(1)
+				.jsonPath("$.offset").isEqualTo(0)
+				.jsonPath("$.limit").isEqualTo(1)
+				.jsonPath(RES0 + "register_id").isEqualTo(007L)
+				.jsonPath(RES0 + "name").isNotEmpty()
+				.jsonPath(RES0 + "name").isEqualTo("Secret Intelligent Service MI6")
+				.jsonPath(RES0 + "created").isNotEmpty()
+				.jsonPath(RES0 + "created").isEqualTo("1909-07-04T00:00:00+00:00")
+				.jsonPath(RES0 + "geo_epgs_4326.x").isEqualTo(51.487222)
+				.jsonPath(RES0 + "geo_epgs_4326.y").isEqualTo(-0.124167);
+		
+		// Verificación de la llamada única al método 'getPage(0,-1)' del servicio
+		getPage0m1.invoke(Mockito.verify(dtoService), 0, -1);
+		
+	} catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException |
+			IllegalArgumentException | InvocationTargetException | NoSuchFieldException e) {
+		
+		throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Failed to return a DTO", e);
+		
+	} }
+	
+	// Generador de argumentos para los ensayos del controlador con los centros económicos
+	private static Arguments[] argsProvider() {
+		
+		final Arguments[] args = {
+			Arguments.of("/big-malls", BigMallsDto.class, "bigMallsService"),
+//			Arguments.of("/market-fairs", MarketFairsDto.class, "marketFairsService"),
+//			Arguments.of("/large-establishments", LargeStablishmentsDto.class, "largeStablishmentsService"),
+//			Arguments.of("/commercial-galleries", CommercialGalleries.class, "commercialGalleriesService")
+		};
+		
+		return args;
+		
+	}
+	
+	@DisplayName("Opendata response -- JSON elements of economic activity codes")
+	@Test
+	public void JsonResponseTests2() {
+		
+		final String URI_TEST = "/economic-activities-census";
+		
+		EconomicActivitiesCensusDto activitatEconomica = new EconomicActivitiesCensusDto();
+		activitatEconomica.Codi_Activitat_2016 = "314159265";
+		activitatEconomica.Codi_Activitat_2019 = "057721566";
+		activitatEconomica.Nom_Activitat = "Exercicis d'apnea";
+		activitatEconomica.Nom_Sector_Activitat = "Flamenco dancing";
+		
+		GenericResultDto<EconomicActivitiesCensusDto> genericResultDTO = new GenericResultDto<>();
+		genericResultDTO.setCount(1);
+		genericResultDTO.setOffset(0);
+		genericResultDTO.setLimit(1);
+		genericResultDTO.setResults(new EconomicActivitiesCensusDto[]{activitatEconomica});
+		
+		Mockito
 			.when(economicActivitiesCensusService.getPage(0,-1))
 			.thenReturn(Mono.just(genericResultDTO));
-    	
-    	webTestClient.get()
+		
+		webTestClient.get()
 			.uri(uriBuilder -> uriBuilder.path(CONTROLLER_BASE_URL + URI_TEST)
 //					.queryParam("offset", 0)
 //					.queryParam("limit", -1)
@@ -265,34 +267,34 @@ public class OpendataControllerTest {
 			.jsonPath(RES0 + "Nom_Activitat").isEqualTo("Exercicis d'apnea")
 			.jsonPath(RES0 + "Nom_Sector_Activitat").isNotEmpty()
 			.jsonPath(RES0 + "Nom_Sector_Activitat").isEqualTo("Flamenco dancing");
-    	
-    	Mockito.verify(economicActivitiesCensusService).getPage(0,-1);
-    	
-    }
-    
-    @DisplayName("Opendata response -- JSON elements of Barcelona's districts ")
-    @Test
-    public void JsonResponseTests3() {
-    	
-    	final String URI_TEST = "/bcn-zones";
-    	
-       	BcnZonesDto
-       		bcnZonesDto1 = new BcnZonesDto(1, "Îles Kerguelen"),
-       		bcnZonesDto2 = new BcnZonesDto(2, "Klendathu");
-    	
-    	BcnZonesResponseDto bcnZonesRespDto
-    			= new BcnZonesResponseDto(2, new BcnZonesDto[]{bcnZonesDto1, bcnZonesDto2}); 
-    	
-    	Mockito
+		
+		Mockito.verify(economicActivitiesCensusService).getPage(0,-1);
+		
+	}
+	
+	@DisplayName("Opendata response -- JSON elements of Barcelona's districts ")
+	@Test
+	public void JsonResponseTests3() {
+		
+		final String URI_TEST = "/bcn-zones";
+		
+		BcnZonesDto
+			bcnZonesDto1 = new BcnZonesDto(1, "Îles Kerguelen"),
+			bcnZonesDto2 = new BcnZonesDto(2, "Klendathu");
+		
+		BcnZonesResponseDto bcnZonesRespDto
+				= new BcnZonesResponseDto(2, new BcnZonesDto[]{bcnZonesDto1, bcnZonesDto2}); 
+		
+		Mockito
 			.when(bcnZonesService.getBcnZones())
 			.thenReturn(Mono.just(bcnZonesRespDto));
-    	
-    	webTestClient.get()
-    			.uri(CONTROLLER_BASE_URL + URI_TEST)
-    			.accept(MediaType.APPLICATION_JSON)
-    			.exchange()
-    			.expectStatus().isOk()
-    			.expectHeader().contentType(MediaType.APPLICATION_JSON)
+		
+		webTestClient.get()
+				.uri(CONTROLLER_BASE_URL + URI_TEST)
+				.accept(MediaType.APPLICATION_JSON)
+				.exchange()
+				.expectStatus().isOk()
+				.expectHeader().contentType(MediaType.APPLICATION_JSON)
 				.expectBody()
 				.jsonPath("$.count").isEqualTo(2)
 				.jsonPath("$.elements[0]." + "id").isEqualTo(1)
@@ -301,9 +303,9 @@ public class OpendataControllerTest {
 				.jsonPath("$.elements[1]." + "id").isEqualTo(2)
 				.jsonPath("$.elements[1]." + "name").isNotEmpty()
 				.jsonPath("$.elements[1]." + "name").isEqualTo("Klendathu");
-    	
-    	Mockito.verify(bcnZonesService).getBcnZones();
-    	
-    }
-    
+		
+		Mockito.verify(bcnZonesService).getBcnZones();
+		
+	}
+	
 }

--- a/BusinessAssistant-opendata/src/test/java/com/businessassistantbcn/opendata/controller/OpendataControllerTest.java
+++ b/BusinessAssistant-opendata/src/test/java/com/businessassistantbcn/opendata/controller/OpendataControllerTest.java
@@ -1,28 +1,53 @@
 package com.businessassistantbcn.opendata.controller;
 
-import com.businessassistantbcn.opendata.service.config.DataConfigService;
-import com.businessassistantbcn.opendata.service.config.TestService;
+import com.businessassistantbcn.opendata.dto.GenericResultDto;
+import com.businessassistantbcn.opendata.dto.bcnzones.*;
+import com.businessassistantbcn.opendata.dto.bigmalls.*;
+import com.businessassistantbcn.opendata.dto.economicactivitiescensus.EconomicActivitiesCensusDto;
+import com.businessassistantbcn.opendata.dto.test.*;
+import com.businessassistantbcn.opendata.service.config.*;
 import com.businessassistantbcn.opendata.service.externaldata.*;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.mockito.Mockito;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.server.ResponseStatusException;
+
+import reactor.core.publisher.Mono;
 
 import static org.hamcrest.Matchers.equalTo;
 
 @ExtendWith(SpringExtension.class)
-@WebFluxTest(OpendataController.class)
+@WebFluxTest(controllers = OpendataController.class)
 public class OpendataControllerTest {
-
+	
     @Autowired
     private WebTestClient webTestClient;
-
-    private final String CONTROLLER_BASE_URL = "/v1/api/opendata";
-
+    
+    private final String
+    	CONTROLLER_BASE_URL = "/v1/api/opendata",
+    	RES0 = "$.results[0].";
+    
     @MockBean
     private BigMallsService bigMallsService;
     @MockBean
@@ -37,11 +62,12 @@ public class OpendataControllerTest {
     private MarketFairsService marketFairsService;
     @MockBean
     private DataConfigService bcnZonesService;
-
+    
+    @DisplayName("Simple String response")
     @Test
     public void testHello(){
-
         final String URI_TEST = "/test";
+        
         webTestClient.get()
                 .uri(CONTROLLER_BASE_URL + URI_TEST)
                 .accept(MediaType.APPLICATION_JSON)
@@ -50,4 +76,234 @@ public class OpendataControllerTest {
                 .expectBody(String.class)
                 .value(s -> s.toString(), equalTo("Hello from BusinessAssistant Barcelona!!!"));
     }
+    
+    @DisplayName("Reactive response -- Star Wars vehicles")
+    @Test
+    public void testReactive() { try {
+    	
+    	final String URI_TEST = "/test-reactive";
+    	
+    	StarWarsVehicleDto vehicleSW = new StarWarsVehicleDto();
+    	vehicleSW.name = "R18 GTD (familiar)";
+    	vehicleSW.model = "Renault 18 GTD";
+    	vehicleSW.manufacturer = "Renault";
+    	vehicleSW.length = 4.487F;
+    	vehicleSW.max_atmosphering_speed = 156;
+    	vehicleSW.crew = 1;
+    	vehicleSW.passengers = 4;
+    	
+    	StarWarsVehiclesResultDto vehiclesResultSW = new StarWarsVehiclesResultDto();
+    	vehiclesResultSW.setCount(1);
+    	vehiclesResultSW.setNext(null);
+    	vehiclesResultSW.setPrevious(null);
+    	vehiclesResultSW.setResults(new StarWarsVehicleDto[]{vehicleSW});
+    	
+    	Mockito
+			.when(testService.getTestData())
+			.thenReturn(Mono.just(vehiclesResultSW));
+    	
+    	webTestClient.get()
+    			.uri(CONTROLLER_BASE_URL + URI_TEST)
+    			.accept(MediaType.APPLICATION_JSON)
+    			.exchange()
+    			.expectStatus().isOk()
+    			.expectHeader().contentType(MediaType.APPLICATION_JSON)
+				.expectBody()
+				.jsonPath("$.count").isEqualTo(1)
+				.jsonPath(RES0 + "name").isNotEmpty()
+    			.jsonPath(RES0 + "name").isEqualTo("R18 GTD (familiar)")
+    			.jsonPath(RES0 + "model").isNotEmpty()
+    			.jsonPath(RES0 + "model").isEqualTo("Renault 18 GTD")
+    			.jsonPath(RES0 + "manufacturer").isNotEmpty()
+    			.jsonPath(RES0 + "manufacturer").isEqualTo("Renault")
+    			.jsonPath(RES0 + "length").isEqualTo(4.487F)
+    			.jsonPath(RES0 + "max_atmosphering_speed").isEqualTo(156)
+    			.jsonPath(RES0 + "crew").isEqualTo(1)
+    			.jsonPath(RES0 + "passengers").isEqualTo(4);
+    	
+    	// Verifica la llamada al método 'getTestData()'.
+    	Mockito.verify(testService).getTestData();
+    	
+    } catch (MalformedURLException e) {
+		throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Resource not found", e);
+	} }
+    
+    @DisplayName("Opendata response -- JSON elements of commercial centers")
+    @ParameterizedTest(name = "{index} -> URL=''{0}''")
+    @MethodSource("argsProvider")
+    public <T> void JsonResponseTests1(String URI_TEST, Class<T> dtoClass, String stringDtoService) { try {
+    	
+    	// Crear un DTO genérico…
+    	Constructor<T> constructor = dtoClass.getConstructor();		
+    	T genericDTO = constructor.newInstance();
+    	
+    	Field
+    		fld_1 = dtoClass.getDeclaredField("register_id"),
+    		fld_2 = dtoClass.getDeclaredField("name"),
+    		fld_3 = dtoClass.getDeclaredField("created"),
+    		fld_4 = dtoClass.getDeclaredField("geo_epgs_4326");
+    	
+    	// y rellenar sus campos con valores.
+    	fld_1.setLong(genericDTO, 007L);	// Afortunadamente, el número también es válido en octal.
+    	fld_2.set(genericDTO, "Secret Intelligent Service MI6");
+    	fld_3.set(genericDTO, "1909-07-04T00:00:00+00:00");
+    	fld_4.set(genericDTO, new CoordinateDto(51.487222, -0.124167));
+    	
+    	// Crear el empaquetamiento para el DTO anterior…
+    	GenericResultDto<T> genericResultDTO = new GenericResultDto<>();
+    	genericResultDTO.setCount(1);
+    	genericResultDTO.setOffset(0);
+    	genericResultDTO.setLimit(1);
+    	
+    	// y guardarlo dentro.
+    	@SuppressWarnings("unchecked")
+		T[] results = (T[])Array.newInstance(dtoClass, 1);
+    	results[0] = genericDTO;
+    	genericResultDTO.setResults(results);
+    	
+    	// Servicio DTO particular.
+    	Field dtoServiceField = this.getClass().getDeclaredField(stringDtoService);
+    	Object dtoService = dtoServiceField.get(this);
+    	
+    	// Método '.getPage(int,int)' dentro del servicio particular.
+    	Method getPage0m1 = dtoServiceField.getType().getDeclaredMethod("getPage", Integer.TYPE, Integer.TYPE);
+    	
+    	// Intercepta la petición de ensayo, devolviendo un 'Mono' con el 'GenericResultDto<genericDto>'
+    	// de un solo resultado fabricado anteriormente. 
+    	Mockito
+			.when(getPage0m1.invoke(dtoService, 0, -1))
+			.thenReturn(Mono.just(genericResultDTO));
+    	
+    	// Petición de prueba a la página web solicitando datos concretos; parámetros 'offset' y 'limit' sin
+    	// especificar -> equivalente a solicitar todos los resultados. Batería de ensayos sobre el objeto
+    	// JSON "retornado".
+    	webTestClient.get()
+    			.uri(uriBuilder -> uriBuilder.path(CONTROLLER_BASE_URL + URI_TEST)
+//    					.queryParam("offset", 0)
+//						.queryParam("limit", -1)
+    					.build())
+    			.accept(MediaType.APPLICATION_JSON)
+    			.exchange()
+    			.expectStatus().isOk()
+    			.expectHeader().contentType(MediaType.APPLICATION_JSON)
+    			.expectBody()
+    			.jsonPath("$.count").isEqualTo(1)
+    			.jsonPath("$.offset").isEqualTo(0)
+    			.jsonPath("$.limit").isEqualTo(1)
+    			.jsonPath(RES0 + "register_id").isEqualTo(007L)
+    			.jsonPath(RES0 + "name").isNotEmpty()
+    			.jsonPath(RES0 + "name").isEqualTo("Secret Intelligent Service MI6")
+    			.jsonPath(RES0 + "created").isNotEmpty()
+    			.jsonPath(RES0 + "created").isEqualTo("1909-07-04T00:00:00+00:00")
+    			.jsonPath(RES0 + "geo_epgs_4326.x").isEqualTo(51.487222)
+    			.jsonPath(RES0 + "geo_epgs_4326.y").isEqualTo(-0.124167);
+    	
+    	// Verificación de la llamada única al método 'getPage(0,-1)' del servicio
+    	getPage0m1.invoke(Mockito.verify(dtoService), 0, -1);
+    	
+    } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException |
+    		IllegalArgumentException | InvocationTargetException | NoSuchFieldException e) {
+    	
+    	throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Failed to return a DTO", e);
+    	
+    } }
+    
+    // Generador de argumentos para los ensayos del controlador con los centros económicos
+    private static Arguments[] argsProvider() {
+    	
+    	final Arguments[] args = {
+    		Arguments.of("/big-malls", BigMallsDto.class, "bigMallsService"),
+//    		Arguments.of("/market-fairs", MarketFairsDto.class, "marketFairsService"),
+//    		Arguments.of("/large-establishments", LargeStablishmentsDto.class, "largeStablishmentsService"),
+//    		Arguments.of("/commercial-galleries", CommercialGalleries.class, "commercialGalleriesService")
+    	};
+    	
+    	return args;
+    	
+    }
+    
+    @DisplayName("Opendata response -- JSON elements of economic activity codes")
+    @Test
+    public void JsonResponseTests2() {
+    	
+    	final String URI_TEST = "/economic-activities-census";
+    	
+    	EconomicActivitiesCensusDto activitatEconomica = new EconomicActivitiesCensusDto();
+    	activitatEconomica.Codi_Activitat_2016 = "314159265";
+    	activitatEconomica.Codi_Activitat_2019 = "057721566";
+    	activitatEconomica.Nom_Activitat = "Exercicis d'apnea";
+    	activitatEconomica.Nom_Sector_Activitat = "Flamenco dancing";
+    	
+    	GenericResultDto<EconomicActivitiesCensusDto> genericResultDTO = new GenericResultDto<>();
+    	genericResultDTO.setCount(1);
+    	genericResultDTO.setOffset(0);
+    	genericResultDTO.setLimit(1);
+    	genericResultDTO.setResults(new EconomicActivitiesCensusDto[]{activitatEconomica});
+    	
+    	Mockito
+			.when(economicActivitiesCensusService.getPage(0,-1))
+			.thenReturn(Mono.just(genericResultDTO));
+    	
+    	webTestClient.get()
+			.uri(uriBuilder -> uriBuilder.path(CONTROLLER_BASE_URL + URI_TEST)
+//					.queryParam("offset", 0)
+//					.queryParam("limit", -1)
+					.build())
+			.accept(MediaType.APPLICATION_JSON)
+			.exchange()
+			.expectStatus().isOk()
+			.expectHeader().contentType(MediaType.APPLICATION_JSON)
+			.expectBody()
+			.jsonPath("$.count").isEqualTo(1)
+			.jsonPath("$.offset").isEqualTo(0)
+			.jsonPath("$.limit").isEqualTo(1)
+			.jsonPath(RES0 + "Codi_Activitat_2016").isNotEmpty()
+			.jsonPath(RES0 + "Codi_Activitat_2016").isEqualTo("314159265")
+			.jsonPath(RES0 + "Codi_Activitat_2019").isNotEmpty()
+			.jsonPath(RES0 + "Codi_Activitat_2019").isEqualTo("057721566")
+			.jsonPath(RES0 + "Nom_Activitat").isNotEmpty()
+			.jsonPath(RES0 + "Nom_Activitat").isEqualTo("Exercicis d'apnea")
+			.jsonPath(RES0 + "Nom_Sector_Activitat").isNotEmpty()
+			.jsonPath(RES0 + "Nom_Sector_Activitat").isEqualTo("Flamenco dancing");
+    	
+    	Mockito.verify(economicActivitiesCensusService).getPage(0,-1);
+    	
+    }
+    
+    @DisplayName("Opendata response -- JSON elements of Barcelona's districts ")
+    @Test
+    public void JsonResponseTests3() {
+    	
+    	final String URI_TEST = "/bcn-zones";
+    	
+       	BcnZonesDto
+       		bcnZonesDto1 = new BcnZonesDto(1, "Îles Kerguelen"),
+       		bcnZonesDto2 = new BcnZonesDto(2, "Klendathu");
+    	
+    	BcnZonesResponseDto bcnZonesRespDto
+    			= new BcnZonesResponseDto(2, new BcnZonesDto[]{bcnZonesDto1, bcnZonesDto2}); 
+    	
+    	Mockito
+			.when(bcnZonesService.getBcnZones())
+			.thenReturn(Mono.just(bcnZonesRespDto));
+    	
+    	webTestClient.get()
+    			.uri(CONTROLLER_BASE_URL + URI_TEST)
+    			.accept(MediaType.APPLICATION_JSON)
+    			.exchange()
+    			.expectStatus().isOk()
+    			.expectHeader().contentType(MediaType.APPLICATION_JSON)
+				.expectBody()
+				.jsonPath("$.count").isEqualTo(2)
+				.jsonPath("$.elements[0]." + "id").isEqualTo(1)
+				.jsonPath("$.elements[0]." + "name").isNotEmpty()
+				.jsonPath("$.elements[0]." + "name").isEqualTo("Îles Kerguelen")
+				.jsonPath("$.elements[1]." + "id").isEqualTo(2)
+				.jsonPath("$.elements[1]." + "name").isNotEmpty()
+				.jsonPath("$.elements[1]." + "name").isEqualTo("Klendathu");
+    	
+    	Mockito.verify(bcnZonesService).getBcnZones();
+    	
+    }
+    
 }


### PR DESCRIPTION
Algunos ensayos no pueden ser testeados hasta que los endpoints con paginación estén hechos. Bastaría con "descomentar" el comando adecuado en las líneas 218 a 220 e importar la clase DTO apropiada.

Ayer comentó al grupo que no podemos utilizar polimorfismo con los DTOs sin perjudicar el rendimiento. Y el lenguaje JAVA no tiene macros. La única solución se me ocurre para automatizar los ensayos sobre los DTOs cuando las clases ya no están relacionadas es usando métodos reflexivos.