### PR TITLE
BABCN-32 OpendataControllerTest (v0.2) + BABCN-49 Paginación /market-fairs

### DIFF
--- a/BusinessAssistant-opendata/build.gradle
+++ b/BusinessAssistant-opendata/build.gradle
@@ -37,7 +37,6 @@ dependencies {
     implementation group: 'org.springframework', name: 'spring-orm', version: '5.3.13'
 
 
-
     // JAX-B dependencies for JDK 9+
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2'
     implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.2'
@@ -52,9 +51,11 @@ dependencies {
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '2.6.1'
 
 
-
-
-
+	compileOnly 'org.projectlombok:lombok:1.18.22'
+	annotationProcessor 'org.projectlombok:lombok:1.18.22'
+	testCompileOnly 'org.projectlombok:lombok:1.18.22'
+	testAnnotationProcessor 'org.projectlombok:lombok:1.18.22'
+	
 }
 
 

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/config/PropertiesConfig.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/config/PropertiesConfig.java
@@ -15,7 +15,7 @@ public class PropertiesConfig {
     private String ds_commercialgaleries;
     private String ds_bigmalls;
     private String ds_municipalmarkets;
-    private String ds_marketsfairs;
+    private String ds_marketfairs;
     private String ds_economicactivitiescensus;
     private String ds_economicactivitiesgroundfloor;
     private Integer maxBytesInMemory;
@@ -77,12 +77,12 @@ public class PropertiesConfig {
         this.ds_municipalmarkets = ds_municipalmarkets;
     }
 
-    public String getDs_marketsfairs() {
-        return ds_marketsfairs;
+    public String getDs_marketfairs() {
+        return ds_marketfairs;
     }
 
-    public void setDs_marketsfairs(String ds_marketsfairs) {
-        this.ds_marketsfairs = ds_marketsfairs;
+    public void setDs_marketfairs(String ds_marketfairs) {
+        this.ds_marketfairs = ds_marketfairs;
     }
 
     public String getDs_economicactivitiescensus() {

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/controller/OpendataController.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/controller/OpendataController.java
@@ -94,34 +94,33 @@ public class OpendataController {
 
     }
 
-    //GET ?offset=0&limit=10
-    @GetMapping("/big-malls")
-    @ApiOperation("Get big malls SET 0 LIMIT 10")
-    @ApiResponses({
-            @ApiResponse(code = 200, message = "OK"),
-            @ApiResponse(code = 400, message = "Offset or Limit cannot be null"),
-            @ApiResponse(code = 404, message = "Not Found"),
-            @ApiResponse(code = 503, message = "Service Unavailable"),
-    })
-    public <T> Mono<T> bigMalls(
-            @ApiParam(value = "Offset", name= "Offset")
-            @RequestParam(required = false) String offset,
-            @ApiParam(value = "Limit", name= "Limit")
-            @RequestParam(required = false)  String limit){
+	//GET ?offset=0&limit=10
+	@SuppressWarnings("unchecked")
+	@GetMapping("/big-malls")
+	@ApiOperation("Get big malls SET 0 LIMIT 10")
+	@ApiResponses({
+			@ApiResponse(code = 200, message = "OK"),
+			@ApiResponse(code = 400, message = "Offset or Limit cannot be null"),
+			@ApiResponse(code = 404, message = "Not Found"),
+			@ApiResponse(code = 503, message = "Service Unavailable"),
+	})
+	public <T> Mono<T> bigMalls(
+			@ApiParam(value = "Offset", name= "Offset")
+			@RequestParam(required = false) String offset,
+			@ApiParam(value = "Limit", name= "Limit")
+			@RequestParam(required = false)  String limit) {
 
-        offset = offset == null ? "0": offset;
-        limit = limit == null ? "-1": limit;
-
-        if(offset.compareTo("")==0 || limit.compareTo("")==0 || offset.compareTo("null")==0 || limit.compareTo("null")==0){
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Offset or Limit cannot be null");
+		offset = offset == null ? "0": offset;
+		limit = limit == null ? "-1": limit;
+		
+		try {
+			return (Mono<T>) bigMallsService.getPage(Integer.parseInt(offset), Integer.parseInt(limit));
+		} catch (Exception e) {
+			throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Resource not found", e);
         }
-        try{
-            return (Mono<T>) bigMallsService.getPage(Integer.parseInt(offset), Integer.parseInt(limit));
-        }catch (Exception mue){
-            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Resource not found", mue);
-        }
-    }
-
+		
+	}
+	
     //GET ?offset=0&limit=10
     @GetMapping("/municipal-markets")
     @ApiOperation("Get municipal markets SET 0 LIMIT 10")
@@ -133,21 +132,33 @@ public class OpendataController {
     {
         return "municipal-markets";
     }
-
-    //GET ?offset=0&limit=10
-    @GetMapping("/market-fairs")
-    @ApiOperation("Get markets fairs SET 0 LIMIT 10")
-    @ApiResponses({
-            @ApiResponse(code = 200, message = "OK"),
-            @ApiResponse(code = 404, message = "Not Found"),
-    })
-    public <T> Mono<T> marketsFairs()
-    {
-    	 try{
-             return (Mono<T>) marketFairsService.getAllMarketsFairs();
-         }catch (Exception mue){
-             throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Resource not found", mue);
-         }    }
+    
+	//GET ?offset=0&limit=10
+	@SuppressWarnings("unchecked")
+	@GetMapping("/market-fairs")
+	@ApiOperation("Get market fairs SET 0 LIMIT 10")
+	@ApiResponses({
+			@ApiResponse(code = 200, message = "OK"),
+			@ApiResponse(code = 400, message = "Offset or Limit cannot be null"),
+			@ApiResponse(code = 404, message = "Not Found"),
+			@ApiResponse(code = 503, message = "Service Unavailable"),
+	})
+	public <T> Mono<T> marketFairs(
+			@ApiParam(value = "Offset", name= "Offset")
+			@RequestParam(required = false) String offset,
+			@ApiParam(value = "Limit", name= "Limit")
+			@RequestParam(required = false)  String limit) {
+		
+		offset = offset == null ? "0": offset;
+		limit = limit == null ? "-1": limit;
+		
+		try {
+			return (Mono<T>) marketFairsService.getPage(Integer.parseInt(offset), Integer.parseInt(limit));
+		} catch (Exception e) {
+			throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Resource not found", e);
+		}
+		
+	}
 
     //GET ?offset=0&limit=10
     @GetMapping("/large-stablishments/activity")

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/bigmalls/BigMallsDto.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/bigmalls/BigMallsDto.java
@@ -1,18 +1,15 @@
 package com.businessassistantbcn.opendata.dto.bigmalls;
 
-
-import com.fasterxml.jackson.annotation.JacksonAnnotation;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 @Component
-//@JsonIgnoreProperties({"tickets_data","entity_types_data","attribute_categories", "values","from_relationships", "to_relationships",
- //       "classifications_data","secondary_filters_data","timetable","image_data","gallery_data","warnings","sections_data"})
+@Getter @Setter
 public class BigMallsDto {
-
+	
     @JsonProperty("register_id")
     private long register_id;
     @JsonProperty("prefix")
@@ -37,7 +34,6 @@ public class BigMallsDto {
     private String body;
     @JsonProperty("tickets_data")
     private List<Object> tickets_data;
-    //prueba con objetos object directamente
     @JsonProperty("addresses")
     private List<Object> addresses;
     @JsonProperty("entity_types_data")
@@ -94,6 +90,5 @@ public class BigMallsDto {
     private String event_status;
     @JsonProperty("ical")
     private String ical;
-
-
+    
 }

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/bigmalls/CoordinateDto.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/bigmalls/CoordinateDto.java
@@ -1,10 +1,19 @@
 package com.businessassistantbcn.opendata.dto.bigmalls;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class CoordinateDto {
-    @JsonProperty("x")
-    float x;
-    @JsonProperty("y")
-    float y;
+	
+	@JsonProperty("x")
+	private double x;
+	@JsonProperty("y")
+	private double y;
+	
 }

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/marketfairs/MarketFairsDto.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/marketfairs/MarketFairsDto.java
@@ -1,38 +1,40 @@
 package com.businessassistantbcn.opendata.dto.marketfairs;
 
-import java.util.List;
-
-import org.springframework.stereotype.Component;
-
 import com.businessassistantbcn.opendata.dto.bigmalls.CoordinateDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
 
 @Component
-public class MarketFairsResponseDto {
+@Getter @Setter
+public class MarketFairsDto {
+	
     @JsonProperty("register_id")
-    public String register_id;
+    private long register_id;
     @JsonProperty("prefix")
-    public String prefix;
+    private String prefix;
     @JsonProperty("suffix")
-    public String suffix;
+    private String suffix;
     @JsonProperty("name")
-    public String name;
+    private String name;
     @JsonProperty("created")
-    public String created;
+    private String created;
     @JsonProperty("modified")
-    public String modified;
+    private String modified;
     @JsonProperty("status")
-    public String status;	
+    private String status;
     @JsonProperty("status_name")
-    public String status_name;
+    private String status_name;
     @JsonProperty("core_type")
-    public String core_type;
+    private String core_type;
     @JsonProperty("core_type_name")
-    public String core_type_name;
+    private String core_type_name;
     @JsonProperty("body")
-    public String body;
+    private String body;
     @JsonProperty("tickets_data")
-    public List<Object> tickets_data;
+    private List<Object> tickets_data;
     @JsonProperty("addresses")
     private List<Object> addresses;
     @JsonProperty("entity_types_data")
@@ -89,4 +91,5 @@ public class MarketFairsResponseDto {
     private String event_status;
     @JsonProperty("ical")
     private String ical;
+    
 }

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/BigMallsService.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/BigMallsService.java
@@ -1,6 +1,5 @@
 package com.businessassistantbcn.opendata.service.externaldata;
 
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
@@ -37,33 +36,26 @@ public class BigMallsService {
 	private HttpClientHelper httpClientHelper;
 	@Autowired
 	private GenericResultDto<BigMallsDto> genericResultDto;
-
-
 	
-	public Mono<GenericResultDto<BigMallsDto>>getPage(int offset, int limit) {
-
-		try {
-			Mono<BigMallsDto[]> response = httpClientHelper.getRequestData(new URL(config.getDs_bigmalls()),
-					BigMallsDto[].class);
-			return response.flatMap(dto ->{
-				try {
-					BigMallsDto[] filteredDto = JsonHelper.filterDto(dto,offset,limit);
-					genericResultDto.setLimit(limit);
-					genericResultDto.setOffset(offset);
-					genericResultDto.setResults(filteredDto);
-					genericResultDto.setCount(dto.length);
-					return Mono.just(genericResultDto);
-				} catch (Exception e) {
-					//Poner Logger
-					throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
-				}
-
-			} );
-
-		} catch (MalformedURLException e) {
-			throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Resource not found", e);
-		}
-	}
+	public Mono<GenericResultDto<BigMallsDto>>getPage(int offset, int limit) { try {
+		
+		Mono<BigMallsDto[]> response = httpClientHelper.getRequestData(new URL(config.getDs_bigmalls()),
+				BigMallsDto[].class);
+		
+		return response.flatMap(dto -> { try {
+			BigMallsDto[] filteredDto = JsonHelper.filterDto(dto, offset, limit);
+			genericResultDto.setLimit(limit);
+			genericResultDto.setOffset(offset);
+			genericResultDto.setResults(filteredDto);
+			genericResultDto.setCount(dto.length);
+			return Mono.just(genericResultDto);
+		} catch (Exception e) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+		} });
+		
+	} catch (MalformedURLException e) {
+		throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Resource not found", e);
+	} }
 	
 	public GenericResultDto<BigMallsDto> getBigMallsByActivityDto(int[] activities, int offset, int limit) {
 		//lambda filter

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/MarketFairsService.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/MarketFairsService.java
@@ -2,12 +2,7 @@ package com.businessassistantbcn.opendata.service.externaldata;
 
 import com.businessassistantbcn.opendata.config.PropertiesConfig;
 import com.businessassistantbcn.opendata.dto.GenericResultDto;
-import com.businessassistantbcn.opendata.dto.bigmalls.BigMallsDto;
-import com.businessassistantbcn.opendata.dto.commercialgalleries.CommercialGalleriesDto;
-import com.businessassistantbcn.opendata.dto.largestablishments.LargeStablishmentsResponseDto;
-import com.businessassistantbcn.opendata.dto.marketfairs.MarketFairsResponseDto;
-import com.businessassistantbcn.opendata.dto.municipalmarkets.MunicipalMarketsResponseDto;
-import com.businessassistantbcn.opendata.dto.test.StarWarsVehiclesResultDto;
+import com.businessassistantbcn.opendata.dto.marketfairs.MarketFairsDto;
 import com.businessassistantbcn.opendata.helper.HttpClientHelper;
 import com.businessassistantbcn.opendata.helper.JsonHelper;
 
@@ -23,32 +18,32 @@ import java.net.URL;
 
 @Service
 public class MarketFairsService {
-    @Autowired
-    PropertiesConfig config;
-    @Autowired
-    HttpClientHelper helper;
-    @Autowired
-	private GenericResultDto<MarketFairsResponseDto> genericResultDto;
-
-    public GenericResultDto<MarketFairsResponseDto> getPage(int offset, int limit) {
-        return null;
-    }
-    
-    public String getAllMarketsFairs(int offset, int limit) {
-    	return null; 
-    }
-    
-	public Mono<GenericResultDto<MarketFairsResponseDto>> getAllMarketsFairs() {
-		try {
-			Mono<MarketFairsResponseDto[]> response = helper.getRequestData(new URL(config.getDs_marketsfairs()),MarketFairsResponseDto[].class);
-			return response.flatMap(dto -> {
-				genericResultDto.setResults(dto);
-				genericResultDto.setCount(dto.length);
-				return Mono.just(genericResultDto);
-			} );
-		} catch (MalformedURLException e) {
-			throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Resource not found", e);
-		}
-	}
-
+	
+	@Autowired
+	private PropertiesConfig config;
+	@Autowired
+	private HttpClientHelper httpClientHelper;
+	@Autowired
+	private GenericResultDto<MarketFairsDto> genericResultDto;
+	
+	public Mono<GenericResultDto<MarketFairsDto>>getPage(int offset, int limit) { try {
+		
+		Mono<MarketFairsDto[]> response = httpClientHelper.getRequestData(new URL(config.getDs_marketfairs()),
+				MarketFairsDto[].class);
+		
+		return response.flatMap(dto -> { try {
+			MarketFairsDto[] filteredDto = JsonHelper.filterDto(dto,offset,limit);
+			genericResultDto.setLimit(limit);
+			genericResultDto.setOffset(offset);
+			genericResultDto.setResults(filteredDto);
+			genericResultDto.setCount(dto.length);
+			return Mono.just(genericResultDto);
+		} catch (Exception e) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+		} });
+		
+	} catch (MalformedURLException e) {
+		throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Resource not found", e);
+	} }
+	
 }

--- a/BusinessAssistant-opendata/src/main/resources/application.yml
+++ b/BusinessAssistant-opendata/src/main/resources/application.yml
@@ -33,7 +33,7 @@ url:
   ds_commercialgaleries: http://www.bcn.cat/tercerlloc/files/mercats-centrescomercials/opendatabcn_mercats-centrescomercials_galeries-comercials-js.json
   ds_bigmalls: http://www.bcn.cat/tercerlloc/files/mercats-centrescomercials/opendatabcn_mercats-centrescomercials_grans-centres-comercials-js.json
   ds_municipalmarkets: http://www.bcn.cat/tercerlloc/files/mercats-centrescomercials/opendatabcn_mercats-centrescomercials_mercats-municipals-js.json
-  ds_marketsfairs: http://www.bcn.cat/tercerlloc/files/mercats-centrescomercials/opendatabcn_mercats-centrescomercials_mercats-fires-al-carrer-js.json
+  ds_marketfairs: http://www.bcn.cat/tercerlloc/files/mercats-centrescomercials/opendatabcn_mercats-centrescomercials_mercats-fires-al-carrer-js.json
   ds_economicactivitiescensus: https://opendata-ajuntament.barcelona.cat/data/dataset/671c46e9-5b85-4e63-8c97-088a2b907cd5/resource/7a3d5380-f79a-424e-be62-dd078efcb40a/download/2019_censcomercialbcn_class_act.json
   ds_economicactivitiesgroundfloor: https://opendata-ajuntament.barcelona.cat/data/dataset/62fb990e-4cc3-457a-aea1-497604e15659/resource/495c434e-b005-416e-b760-dc79f56dff3a/download/2019_censcomercialbcn_detall.geojson
   districts:

--- a/BusinessAssistant-opendata/src/test/java/com/businessassistantbcn/opendata/controller/OpendataControllerTest.java
+++ b/BusinessAssistant-opendata/src/test/java/com/businessassistantbcn/opendata/controller/OpendataControllerTest.java
@@ -1,53 +1,313 @@
 package com.businessassistantbcn.opendata.controller;
 
-import com.businessassistantbcn.opendata.service.config.DataConfigService;
-import com.businessassistantbcn.opendata.service.config.TestService;
+import com.businessassistantbcn.opendata.dto.GenericResultDto;
+import com.businessassistantbcn.opendata.dto.bcnzones.*;
+import com.businessassistantbcn.opendata.dto.bigmalls.*;
+import com.businessassistantbcn.opendata.dto.economicactivitiescensus.EconomicActivitiesCensusDto;
+import com.businessassistantbcn.opendata.dto.marketfairs.MarketFairsDto;
+import com.businessassistantbcn.opendata.dto.test.*;
+import com.businessassistantbcn.opendata.service.config.*;
 import com.businessassistantbcn.opendata.service.externaldata.*;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.mockito.Mockito;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.server.ResponseStatusException;
+
+import reactor.core.publisher.Mono;
 
 import static org.hamcrest.Matchers.equalTo;
 
 @ExtendWith(SpringExtension.class)
-@WebFluxTest(OpendataController.class)
+@WebFluxTest(controllers = OpendataController.class)
 public class OpendataControllerTest {
-
-    @Autowired
-    private WebTestClient webTestClient;
-
-    private final String CONTROLLER_BASE_URL = "/v1/api/opendata";
-
-    @MockBean
-    private BigMallsService bigMallsService;
-    @MockBean
-    private TestService testService;
-    @MockBean
-    private EconomicActivitiesCensusService economicActivitiesCensusService;
-    @MockBean
-    private CommercialGalleriesService commercialGalleriesService;
-    @MockBean
-    private LargeStablishmentsService largeStablishmentsService;
-    @MockBean
-    private MarketFairsService marketFairsService;
-    @MockBean
-    private DataConfigService bcnZonesService;
-
-    @Test
-    public void testHello(){
-
-        final String URI_TEST = "/test";
-        webTestClient.get()
-                .uri(CONTROLLER_BASE_URL + URI_TEST)
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody(String.class)
-                .value(s -> s.toString(), equalTo("Hello from BusinessAssistant Barcelona!!!"));
-    }
+	
+	@Autowired
+	private WebTestClient webTestClient;
+	
+	private final String
+		CONTROLLER_BASE_URL = "/v1/api/opendata",
+		RES0 = "$.results[0].";
+	
+	@MockBean
+	private BigMallsService bigMallsService;
+	@MockBean
+	private TestService testService;
+	@MockBean
+	private EconomicActivitiesCensusService economicActivitiesCensusService;
+	@MockBean
+	private CommercialGalleriesService commercialGalleriesService;
+	@MockBean
+	private LargeStablishmentsService largeStablishmentsService;
+	@MockBean
+	private MarketFairsService marketFairsService;
+	@MockBean
+	private DataConfigService bcnZonesService;
+	
+	@DisplayName("Simple String response")
+	@Test
+	public void testHello(){
+		
+		final String URI_TEST = "/test";
+		
+		webTestClient.get()
+				.uri(CONTROLLER_BASE_URL + URI_TEST)
+				.accept(MediaType.APPLICATION_JSON)
+				.exchange()
+				.expectStatus().isOk()
+				.expectBody(String.class)
+				.value(s -> s.toString(), equalTo("Hello from BusinessAssistant Barcelona!!!"));
+		
+	}
+	
+	@DisplayName("Reactive response -- Star Wars vehicles")
+	@Test
+	public void testReactive() { try {
+		
+		final String URI_TEST = "/test-reactive";
+		
+		StarWarsVehicleDto vehicleSW = new StarWarsVehicleDto();
+		vehicleSW.name = "R18 GTD (familiar)";
+		vehicleSW.model = "Renault 18 GTD";
+		vehicleSW.manufacturer = "Renault";
+		vehicleSW.length = 4.487F;
+		vehicleSW.max_atmosphering_speed = 156;
+		vehicleSW.crew = 1;
+		vehicleSW.passengers = 4;
+		
+		StarWarsVehiclesResultDto vehiclesResultSW = new StarWarsVehiclesResultDto();
+		vehiclesResultSW.setCount(1);
+		vehiclesResultSW.setNext(null);
+		vehiclesResultSW.setPrevious(null);
+		vehiclesResultSW.setResults(new StarWarsVehicleDto[]{vehicleSW});
+		
+		Mockito
+			.when(testService.getTestData())
+			.thenReturn(Mono.just(vehiclesResultSW));
+		
+		webTestClient.get()
+				.uri(CONTROLLER_BASE_URL + URI_TEST)
+				.accept(MediaType.APPLICATION_JSON)
+				.exchange()
+				.expectStatus().isOk()
+				.expectHeader().contentType(MediaType.APPLICATION_JSON)
+				.expectBody()
+				.jsonPath("$.count").isEqualTo(1)
+				.jsonPath(RES0 + "name").isNotEmpty()
+				.jsonPath(RES0 + "name").isEqualTo("R18 GTD (familiar)")
+				.jsonPath(RES0 + "model").isNotEmpty()
+				.jsonPath(RES0 + "model").isEqualTo("Renault 18 GTD")
+				.jsonPath(RES0 + "manufacturer").isNotEmpty()
+				.jsonPath(RES0 + "manufacturer").isEqualTo("Renault")
+				.jsonPath(RES0 + "length").isEqualTo(4.487F)
+				.jsonPath(RES0 + "max_atmosphering_speed").isEqualTo(156)
+				.jsonPath(RES0 + "crew").isEqualTo(1)
+				.jsonPath(RES0 + "passengers").isEqualTo(4);
+		
+		// Verifica la llamada al método 'getTestData()'.
+		Mockito.verify(testService).getTestData();
+		
+	} catch (MalformedURLException e) {
+		throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Resource not found", e);
+	} }
+	
+	@DisplayName("Opendata response -- JSON elements of commercial centers")
+	@ParameterizedTest(name = "{index} -> URL=''{0}''")
+	@MethodSource("argsProvider")
+	public <T> void JsonResponseTests1(String URI_TEST, Class<T> dtoClass, String stringDtoService) { try {
+		
+		// Crear un DTO genérico…
+		Constructor<T> constructor = dtoClass.getConstructor();		
+		T genericDTO = constructor.newInstance();
+		
+		// … apuntar a sus Setters …
+		Method
+			mtd_1 = dtoClass.getDeclaredMethod("setRegister_id", Long.TYPE),
+			mtd_2 = dtoClass.getDeclaredMethod("setName", String.class),
+			mtd_3 = dtoClass.getDeclaredMethod("setCreated", String.class),
+			mtd_4 = dtoClass.getDeclaredMethod("setGeo_epgs_4326", CoordinateDto.class);
+		
+		// … y rellenar sus campos con valores.
+		mtd_1.invoke(genericDTO, 007L);	// Afortunadamente, el número también es válido en octal.
+		mtd_2.invoke(genericDTO, "Secret Intelligent Service MI6");
+		mtd_3.invoke(genericDTO, "1909-07-04T00:00:00+00:00");
+		mtd_4.invoke(genericDTO, new CoordinateDto(51.487222, -0.124167));
+		
+		// Crear el empaquetamiento para el DTO anterior …
+		GenericResultDto<T> genericResultDTO = new GenericResultDto<>();
+		genericResultDTO.setCount(1);
+		genericResultDTO.setOffset(0);
+		genericResultDTO.setLimit(1);
+		
+		// … y guardarlo dentro.
+		@SuppressWarnings("unchecked")
+		T[] results = (T[])Array.newInstance(dtoClass, 1);
+		results[0] = genericDTO;
+		genericResultDTO.setResults(results);
+		
+		// Servicio DTO particular.
+		Field dtoServiceField = this.getClass().getDeclaredField(stringDtoService);
+		Object dtoService = dtoServiceField.get(this);
+		
+		// Método '.getPage(int,int)' dentro del servicio particular.
+		Method getPage0m1 = dtoServiceField.getType().getDeclaredMethod("getPage", Integer.TYPE, Integer.TYPE);
+		
+		// Intercepta la petición de ensayo, devolviendo un 'Mono' con el 'GenericResultDto<genericDto>'
+		// de un solo resultado fabricado anteriormente. 
+		Mockito
+			.when(getPage0m1.invoke(dtoService, 0, -1))
+			.thenReturn(Mono.just(genericResultDTO));
+		
+		// Petición de prueba a la página web solicitando datos concretos; parámetros 'offset' y 'limit' sin
+		// especificar -> equivalente a solicitar todos los resultados. Batería de ensayos sobre el objeto
+		// JSON "retornado".
+		webTestClient.get()
+				.uri(uriBuilder -> uriBuilder.path(CONTROLLER_BASE_URL + URI_TEST)
+//						.queryParam("offset", 0)
+//						.queryParam("limit", -1)
+						.build())
+				.accept(MediaType.APPLICATION_JSON)
+				.exchange()
+				.expectStatus().isOk()
+				.expectHeader().contentType(MediaType.APPLICATION_JSON)
+				.expectBody()
+				.jsonPath("$.count").isEqualTo(1)
+				.jsonPath("$.offset").isEqualTo(0)
+				.jsonPath("$.limit").isEqualTo(1)
+				.jsonPath(RES0 + "register_id").isEqualTo(007L)
+				.jsonPath(RES0 + "name").isNotEmpty()
+				.jsonPath(RES0 + "name").isEqualTo("Secret Intelligent Service MI6")
+				.jsonPath(RES0 + "created").isNotEmpty()
+				.jsonPath(RES0 + "created").isEqualTo("1909-07-04T00:00:00+00:00")
+				.jsonPath(RES0 + "geo_epgs_4326.x").isEqualTo(51.487222)
+				.jsonPath(RES0 + "geo_epgs_4326.y").isEqualTo(-0.124167);
+		
+		// Verificación de la llamada única al método 'getPage(0,-1)' del servicio
+		getPage0m1.invoke(Mockito.verify(dtoService), 0, -1);
+		
+	} catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException |
+			IllegalArgumentException | InvocationTargetException | NoSuchFieldException e) {
+		
+		throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Failed to return a DTO", e);
+		
+	} }
+	
+	// Generador de argumentos para los ensayos del controlador con los centros económicos
+	private static Arguments[] argsProvider() {
+		
+		final Arguments[] args = {
+			Arguments.of("/big-malls", BigMallsDto.class, "bigMallsService"),
+			Arguments.of("/market-fairs", MarketFairsDto.class, "marketFairsService"),
+//			Arguments.of("/large-establishments", LargeStablishmentsDto.class, "largeStablishmentsService"),
+//			Arguments.of("/commercial-galleries", CommercialGalleries.class, "commercialGalleriesService")
+		};
+		
+		return args;
+		
+	}
+	
+	@DisplayName("Opendata response -- JSON elements of economic activity codes")
+	@Test
+	public void JsonResponseTests2() {
+		
+		final String URI_TEST = "/economic-activities-census";
+		
+		EconomicActivitiesCensusDto activitatEconomica = new EconomicActivitiesCensusDto();
+		activitatEconomica.Codi_Activitat_2016 = "314159265";
+		activitatEconomica.Codi_Activitat_2019 = "057721566";
+		activitatEconomica.Nom_Activitat = "Exercicis d'apnea";
+		activitatEconomica.Nom_Sector_Activitat = "Flamenco dancing";
+		
+		GenericResultDto<EconomicActivitiesCensusDto> genericResultDTO = new GenericResultDto<>();
+		genericResultDTO.setCount(1);
+		genericResultDTO.setOffset(0);
+		genericResultDTO.setLimit(1);
+		genericResultDTO.setResults(new EconomicActivitiesCensusDto[]{activitatEconomica});
+		
+		Mockito
+			.when(economicActivitiesCensusService.getPage(0,-1))
+			.thenReturn(Mono.just(genericResultDTO));
+		
+		webTestClient.get()
+			.uri(uriBuilder -> uriBuilder.path(CONTROLLER_BASE_URL + URI_TEST)
+//					.queryParam("offset", 0)
+//					.queryParam("limit", -1)
+					.build())
+			.accept(MediaType.APPLICATION_JSON)
+			.exchange()
+			.expectStatus().isOk()
+			.expectHeader().contentType(MediaType.APPLICATION_JSON)
+			.expectBody()
+			.jsonPath("$.count").isEqualTo(1)
+			.jsonPath("$.offset").isEqualTo(0)
+			.jsonPath("$.limit").isEqualTo(1)
+			.jsonPath(RES0 + "Codi_Activitat_2016").isNotEmpty()
+			.jsonPath(RES0 + "Codi_Activitat_2016").isEqualTo("314159265")
+			.jsonPath(RES0 + "Codi_Activitat_2019").isNotEmpty()
+			.jsonPath(RES0 + "Codi_Activitat_2019").isEqualTo("057721566")
+			.jsonPath(RES0 + "Nom_Activitat").isNotEmpty()
+			.jsonPath(RES0 + "Nom_Activitat").isEqualTo("Exercicis d'apnea")
+			.jsonPath(RES0 + "Nom_Sector_Activitat").isNotEmpty()
+			.jsonPath(RES0 + "Nom_Sector_Activitat").isEqualTo("Flamenco dancing");
+		
+		Mockito.verify(economicActivitiesCensusService).getPage(0,-1);
+		
+	}
+	
+	@DisplayName("Opendata response -- JSON elements of Barcelona's districts ")
+	@Test
+	public void JsonResponseTests3() {
+		
+		final String URI_TEST = "/bcn-zones";
+		
+		BcnZonesDto
+			bcnZonesDto1 = new BcnZonesDto(1, "Îles Kerguelen"),
+			bcnZonesDto2 = new BcnZonesDto(2, "Klendathu");
+		
+		BcnZonesResponseDto bcnZonesRespDto
+				= new BcnZonesResponseDto(2, new BcnZonesDto[]{bcnZonesDto1, bcnZonesDto2}); 
+		
+		Mockito
+			.when(bcnZonesService.getBcnZones())
+			.thenReturn(Mono.just(bcnZonesRespDto));
+		
+		webTestClient.get()
+				.uri(CONTROLLER_BASE_URL + URI_TEST)
+				.accept(MediaType.APPLICATION_JSON)
+				.exchange()
+				.expectStatus().isOk()
+				.expectHeader().contentType(MediaType.APPLICATION_JSON)
+				.expectBody()
+				.jsonPath("$.count").isEqualTo(2)
+				.jsonPath("$.elements[0]." + "id").isEqualTo(1)
+				.jsonPath("$.elements[0]." + "name").isNotEmpty()
+				.jsonPath("$.elements[0]." + "name").isEqualTo("Îles Kerguelen")
+				.jsonPath("$.elements[1]." + "id").isEqualTo(2)
+				.jsonPath("$.elements[1]." + "name").isNotEmpty()
+				.jsonPath("$.elements[1]." + "name").isEqualTo("Klendathu");
+		
+		Mockito.verify(bcnZonesService).getBcnZones();
+		
+	}
+	
 }


### PR DESCRIPTION
BABCN-32: Segunda versión de OpendataControllerTest

Campos 'public' -> getters/setters "Lombok" (para las clases DTO en las que estoy involucrado. No he pisado—creo—el trabajo de otros).

Ensayos operativos para "/test", "/test-reactive" (StarWars), "/big-malls", "/market-fairs", "/economic-activities-census" (¿códigos de actividades económicas?) y "/bcn-zones" (distritos de Barcelona).

---------------------------------------------------------------------------------------------

BABCN-49: Paginación para respuesta "/market-fairs"

Sé que debería haber separado esto en una segunda PR, pero puesto que el nuevo código es básicamente copiar y pegar lo que ya hay en "BigMalls", y me venía bien una segunda clase para verificar mis ensayos en el tester anterior, lo subo todo junto.

También he arreglado algunas referencias a "marketsfairs" (con la 's' de más) en el archivo/clase de configuración. Quedarían todas las "galeries" (con una 'l' de menos).