### PR TITLE
BABCN-31 Filtro por distrito en LargeStablishmentsService

### DIFF
--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/controller/OpendataController.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/controller/OpendataController.java
@@ -70,22 +70,6 @@ public class OpendataController {
     }
 
     //GET ?offset=0&limit=10
-    @GetMapping("/large-stablishments")
-    @ApiOperation("Get large establishments SET 0 LIMIT 10")
-    @ApiResponses({
-            @ApiResponse(code = 200, message = "OK"),
-            @ApiResponse(code = 404, message = "Not Found"),
-    })
-    public Mono<?> largeEstablishments()
-    {
-        try{
-            return largeStablishmentsService.getLargeStablishmentsAll();
-        }catch (Exception mue){
-            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Resource not found", mue);
-        }
-    }
-
-    //GET ?offset=0&limit=10
     @GetMapping("/commercial-galleries")
     @ApiOperation("Get commercial galleries SET 0 LIMIT 10")
     @ApiResponses({
@@ -103,32 +87,59 @@ public class OpendataController {
 
     }
     
-  //GET ?offset=0&limit=10
-    @GetMapping("/large-establishments/district/{district}")
-    @ApiOperation("Get large establishments SET 0 LIMIT 10")
-    @ApiResponses({
-            @ApiResponse(code = 200, message = "OK"),
-            @ApiResponse(code = 400, message = "Offset or Limit cannot be null"),
-            @ApiResponse(code = 404, message = "Not Found"),
-            @ApiResponse(code = 503, message = "Service Unavailable"),
-    })
-
-    public Mono<?> largeEstablishmentsByDistrict(
-    		@ApiParam(value = "Offset", name= "Offset")
-            @RequestParam(required = false) String offset,
-            @ApiParam(value = "Limit", name= "Limit")
-            @RequestParam(required = false)  String limit,
-            @PathVariable("district") String district){
-    	
-    	 offset = offset == null ? "0": offset;
-         limit = limit == null ? "-1": limit;
-         
-         try{
-        	 return largeStablishmentsService.getPageByDistrict(Integer.parseInt(offset), Integer.parseInt(limit), district);
-         }catch (Exception mue){
-             throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Resource not found", mue);
-         }
-    }
+	//GET ?offset=0&limit=10
+	@GetMapping("/large-stablishments")
+	@ApiOperation("Get large establishments SET 0 LIMIT 10")
+	@ApiResponses({
+			@ApiResponse(code = 200, message = "OK"),
+			@ApiResponse(code = 400, message = "Offset or Limit cannot be null"),
+			@ApiResponse(code = 404, message = "Not Found"),
+			@ApiResponse(code = 503, message = "Service Unavailable"),
+	})
+	
+	public Mono<?> largeEstablishments(
+			@ApiParam(value = "Offset", name= "Offset")
+			@RequestParam(required = false) String offset,
+			@ApiParam(value = "Limit", name= "Limit")
+			@RequestParam(required = false)  String limit) { try {
+		
+		int
+			offsetI = offset == null ? 0: Integer.parseInt(offset),
+			limitI = limit == null ? -1: Integer.parseInt(limit);
+		
+		return largeStablishmentsService.getPage(offsetI, limitI);
+	} catch(Exception e) {
+		throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Resource not found", e);
+	} }
+	
+	//GET ?offset=0&limit=10
+	@GetMapping("/large-establishments/district/{district}")
+	@ApiOperation("Get large establishments filtered by district SET 0 LIMIT 10")
+	@ApiResponses({
+			@ApiResponse(code = 200, message = "OK"),
+			@ApiResponse(code = 400, message = "Offset or Limit cannot be null"),
+			@ApiResponse(code = 404, message = "Not Found"),
+			@ApiResponse(code = 503, message = "Service Unavailable"),
+	})
+	
+	public Mono<?> largeEstablishmentsByDistrict(
+			@ApiParam(value = "Offset", name= "Offset")
+			@RequestParam(required = false) String offset,
+			@ApiParam(value = "Limit", name= "Limit")
+			@RequestParam(required = false)  String limit,
+			@PathVariable("district") String district) { try {
+		
+		int
+			offsetI = offset == null ? 0: Integer.parseInt(offset),
+			limitI = limit == null ? -1: Integer.parseInt(limit),
+			districtI = district == null ? 0: Integer.parseInt(district);
+			// NOTE: district zero does not exist!
+		
+		return largeStablishmentsService.getPageByDistrict(offsetI, limitI, districtI);
+	} catch(Exception e) {
+		throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Resource not found", e);
+	} }
+	
     //GET ?offset=0&limit=10
     @GetMapping("/big-malls")
     @ApiOperation("Get big malls SET 0 LIMIT 10")

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/controller/OpendataController.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/controller/OpendataController.java
@@ -94,7 +94,7 @@ public class OpendataController {
 			@ApiResponse(code = 200, message = "OK"),
 			@ApiResponse(code = 400, message = "Offset or Limit cannot be null"),
 			@ApiResponse(code = 404, message = "Not Found"),
-			@ApiResponse(code = 503, message = "Service Unavailable"),
+			@ApiResponse(code = 503, message = "Service Unavailable")
 	})
 	
 	public Mono<?> largeEstablishments(
@@ -104,8 +104,8 @@ public class OpendataController {
 			@RequestParam(required = false)  String limit) { try {
 		
 		int
-			offsetI = offset == null ? 0: Integer.parseInt(offset),
-			limitI = limit == null ? -1: Integer.parseInt(limit);
+			offsetI = offset == null ? 0 : Integer.parseInt(offset),
+			limitI = limit == null ? -1 : Integer.parseInt(limit);
 		
 		return largeStablishmentsService.getPage(offsetI, limitI);
 	} catch(Exception e) {
@@ -119,7 +119,7 @@ public class OpendataController {
 			@ApiResponse(code = 200, message = "OK"),
 			@ApiResponse(code = 400, message = "Offset or Limit cannot be null"),
 			@ApiResponse(code = 404, message = "Not Found"),
-			@ApiResponse(code = 503, message = "Service Unavailable"),
+			@ApiResponse(code = 503, message = "Service Unavailable")
 	})
 	
 	public Mono<?> largeEstablishmentsByDistrict(
@@ -127,13 +127,12 @@ public class OpendataController {
 			@RequestParam(required = false) String offset,
 			@ApiParam(value = "Limit", name= "Limit")
 			@RequestParam(required = false)  String limit,
-			@PathVariable("district") String district) { try {
+			@PathVariable(value = "district") String district) { try {
 		
 		int
-			offsetI = offset == null ? 0: Integer.parseInt(offset),
-			limitI = limit == null ? -1: Integer.parseInt(limit),
-			districtI = district == null ? 0: Integer.parseInt(district);
-			// NOTE: district zero does not exist!
+			offsetI = offset == null ? 0 : Integer.parseInt(offset),
+			limitI = limit == null ? -1 : Integer.parseInt(limit),
+			districtI = Integer.parseInt(district);
 		
 		return largeStablishmentsService.getPageByDistrict(offsetI, limitI, districtI);
 	} catch(Exception e) {

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/bigmalls/AddressDto.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/bigmalls/AddressDto.java
@@ -48,7 +48,7 @@ public class AddressDto {
     @JsonProperty("comments")
     private String comments;
     @JsonProperty("position")
-    private String position;
+    private int position;
     @JsonProperty("main_address")
     private boolean main_address;
     @JsonProperty("road_name")

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/largestablishments/LargeStablishmentsDto.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/largestablishments/LargeStablishmentsDto.java
@@ -1,7 +1,7 @@
 package com.businessassistantbcn.opendata.dto.largestablishments;
 
 import com.businessassistantbcn.opendata.dto.bigmalls.CoordinateDto;
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.businessassistantbcn.opendata.dto.bigmalls.AddressDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.Getter;
@@ -37,7 +37,7 @@ public class LargeStablishmentsDto {
     @JsonProperty("tickets_data")
     private List<Object> tickets_data;
     @JsonProperty("addresses")
-    private List<Object> addresses;
+    private List<AddressDto> addresses;
     @JsonProperty("entity_types_data")
     private List<Object> entity_types_data;
     @JsonProperty("attribute_categories")
@@ -66,9 +66,8 @@ public class LargeStablishmentsDto {
     private CoordinateDto geo_epgs_23031;
     @JsonProperty("geo_epgs_4326")
     private CoordinateDto geo_epgs_4326;
-    @JsonIgnore
     @JsonProperty("is_section_of_data")
-    private boolean is_section_of_data;
+    private Object is_section_of_data;
     @JsonProperty("sections_data")
     private List<Object> sections_data;
     @JsonProperty("start_date")

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/largestablishments/LargeStablishmentsDto.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/largestablishments/LargeStablishmentsDto.java
@@ -1,7 +1,7 @@
 package com.businessassistantbcn.opendata.dto.largestablishments;
 
-import com.businessassistantbcn.opendata.dto.bigmalls.CoordinateDto;
 import com.businessassistantbcn.opendata.dto.bigmalls.AddressDto;
+import com.businessassistantbcn.opendata.dto.bigmalls.CoordinateDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.Getter;

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/helper/JsonHelper.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/helper/JsonHelper.java
@@ -2,8 +2,8 @@ package com.businessassistantbcn.opendata.helper;
 
 import java.util.Arrays;
 import java.util.List;
-
-import net.bytebuddy.implementation.bytecode.Throw;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,4 +85,20 @@ public class JsonHelper<T> {
 
 		return filteredDto;
 	}
+	
+	// Returns stream starting from 'offset', with 'limit' elements.
+	// Returns all elements if limit < 0.
+	public static <T> T[] pageDto(T[] dto, int offset, int limit) {
+		if(offset > dto.length)
+			offset = dto.length;
+		else if(offset < 0)
+			offset = 0;
+		
+		int end = limit < 0 ? dto.length : offset + limit;
+		if(end > dto.length)
+			end = dto.length;
+		
+		return Arrays.copyOfRange(dto, offset, end);
+	}
+	
 }

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/LargeStablishmentsService.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/LargeStablishmentsService.java
@@ -29,7 +29,7 @@ public class LargeStablishmentsService {
 	private GenericResultDto<LargeStablishmentsDto> genericResultDto;
 	
 	// Get paged results
-	public Mono<GenericResultDto<LargeStablishmentsDto>>getPage(int offset, int limit) {
+	public Mono<GenericResultDto<LargeStablishmentsDto>> getPage(int offset, int limit) {
 		return getResultDto(offset, limit, dto -> true);
 	}
 	
@@ -39,6 +39,11 @@ public class LargeStablishmentsService {
 				dto.getAddresses().stream().anyMatch(a ->
 						Integer.parseInt(a.getDistrict_id()) == district
 		));
+	}
+	
+	// Get paged results filtered by activity
+	public Mono<GenericResultDto<LargeStablishmentsDto>> getPageByActivity(int offset, int limit, int activity) {
+		return null; // *** FILTRO PENDIENTE ***
 	}
 	
 	private Mono<GenericResultDto<LargeStablishmentsDto>> getResultDto(

--- a/BusinessAssistant-opendata/src/test/java/com/businessassistantbcn/opendata/controller/OpendataControllerTest.java
+++ b/BusinessAssistant-opendata/src/test/java/com/businessassistantbcn/opendata/controller/OpendataControllerTest.java
@@ -222,7 +222,7 @@ public class OpendataControllerTest {
 			Arguments.of("/big-malls", BigMallsDto.class, "bigMallsService"),
 			Arguments.of("/market-fairs", MarketFairsDto.class, "marketFairsService"),
 			Arguments.of("/municipal-markets", MunicipalMarketsDto.class, "municipalMarketsService"),
-//			Arguments.of("/large-establishments", LargeStablishmentsDto.class, "largeStablishmentsService"),
+//			Arguments.of("/large-stablishments", LargeStablishmentsDto.class, "largeStablishmentsService"),
 //			Arguments.of("/commercial-galleries", CommercialGalleries.class, "commercialGalleriesService")
 		};
 		


### PR DESCRIPTION
Añadido filtro (programción funcional) para el servicio LargeStablishmentsService.
(Usa un nuevo método auxiliar en JsonHelper que no lanza excepciones cuando los valores 'offset' y 'limit' caen fuera del rango de resultados—es menos problemático con los resultados filtrados.)

Enmiendas a OpendataController para los dos endpoints de LargeStablishments.
*** NOTA: Endpoint @GetMapping("/large-stablishments") transformado en @GetMapping("/large-establishments") por uniformidad con el GET filtrado. Existe discrepancias en los tickets Trello; 'ARQUITECTURA BACKEND' no coincide con 'ENDPOINTS' para las peticiones LargeStablishments. ***

Añadidos ensayos en OpendataControllerTest para los endpoints "/large-establishments" y "/commercial-galleries"