### PR TITLE
BABCN-81 - OpenData: Security filter added

### DIFF
--- a/BusinessAssistant-opendata/build.gradle
+++ b/BusinessAssistant-opendata/build.gradle
@@ -39,6 +39,11 @@ dependencies {
     implementation group: 'org.springframework', name: 'spring-context', version: '5.3.15'
     implementation group: 'org.springframework', name: 'spring-context-support', version: '5.3.15'
     implementation group: 'org.springframework', name: 'spring-orm', version: '5.3.13'
+    
+    //security
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: '2.5.6'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2', 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
     // JAX-B dependencies for JDK 9+
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2'

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/config/HttpSecurityConfig.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/config/HttpSecurityConfig.java
@@ -1,0 +1,61 @@
+package com.businessassistantbcn.opendata.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
+
+import com.businessassistantbcn.opendata.security.JwtAuthenticationFilter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Configuration
+public class HttpSecurityConfig {
+
+    @Profile("dev")
+    @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
+    @EnableWebSecurity
+    public static class DisableSecurityConfig extends WebSecurityConfigurerAdapter {
+        @Override
+        public void configure(HttpSecurity http) throws Exception {
+            http.authorizeRequests().anyRequest().permitAll();
+        }
+    }
+
+    @Profile("pro")
+    @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
+    @EnableWebSecurity
+    public static class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+        @Autowired
+        private SecurityPropertiesConfig config;
+        @Autowired
+        private JwtAuthenticationFilter jwtFilter;
+        @Override
+        public void configure(HttpSecurity http) throws Exception {
+            http.csrf().disable();
+            http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+            http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+            http.authorizeRequests().anyRequest().authenticated();
+            http.exceptionHandling().authenticationEntryPoint(
+                    new BasicAuthenticationEntryPoint() {
+                        @Override
+                        public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+                                throws IOException {
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.getWriter().print(config.getErr());
+                        }
+                    }
+            );
+        }
+    }
+}

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/config/SecurityPropertiesConfig.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/config/SecurityPropertiesConfig.java
@@ -1,0 +1,20 @@
+package com.businessassistantbcn.opendata.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Configuration
+@EnableConfigurationProperties
+@ConfigurationProperties("security.datasource")
+@Getter @Setter
+public class SecurityPropertiesConfig {
+
+	private String secret;
+	private String headerString;
+	private String authoritiesClaim;
+	private String err;
+}

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/security/JwtAuthenticationFilter.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/security/JwtAuthenticationFilter.java
@@ -1,0 +1,77 @@
+package com.businessassistantbcn.opendata.security;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.businessassistantbcn.opendata.config.SecurityPropertiesConfig;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter{
+
+    @Autowired
+    private SecurityPropertiesConfig config;
+
+    private final String TOKEN_PREFIX = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain)
+            throws IOException, ServletException {
+        try {
+            String authorizationHeader = request.getHeader(config.getHeaderString());
+            if(authorizationHeaderIsValid(authorizationHeader)) {
+                Claims claims = validateToken(request);
+                setUpSpringAuthentication(claims);
+            }
+            filterChain.doFilter(request, response);
+        } catch(ExpiredJwtException | UnsupportedJwtException | MalformedJwtException | SignatureException e) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        }
+    }
+
+    private boolean authorizationHeaderIsValid(String authorizationHeader) {
+        return authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX);
+    }
+
+    private Claims validateToken(HttpServletRequest request) {
+        String jwtToken = request.getHeader(config.getHeaderString()).replace(TOKEN_PREFIX, "").trim();
+        return Jwts.parserBuilder()
+                .setSigningKey(config.getSecret().getBytes())
+                .build()
+                .parseClaimsJws(jwtToken)
+                .getBody();
+    }
+
+    private void setUpSpringAuthentication(Claims claims) {
+        @SuppressWarnings("unchecked")
+        List<String> authorities = (List<String>)claims.get(config.getAuthoritiesClaim());
+
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                claims.getSubject(), null,
+                authorities.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList()));
+
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    }
+}

--- a/BusinessAssistant-opendata/src/main/resources/application.yml
+++ b/BusinessAssistant-opendata/src/main/resources/application.yml
@@ -20,6 +20,12 @@ spring:
         prefer-ip-address: true
         healthCheckPath: ${management.server.servlet.context-path}/health
         healthCheckInterval: 15s
+  #Spring profiles available:
+  #   - dev: disable security
+  #   - pro: enable JWT security
+  profiles:
+    active:
+    - dev   
 
 # OJO bug afecta a Swagger
 springfox:
@@ -58,6 +64,12 @@ url:
     - "Sant Andreu"
     - "Sant Martí"
 
+security:
+  datasource:
+    secret: SgVkYp3s6v9y$B&E)H+MbQeThWmZq4t7
+    headerString: Authorization
+    authoritiesClaim: authorities
+    err: Auth Error, Token Unavailable 
 ---
 logging:
   level:

--- a/BusinessAssistant-opendata/src/test/java/com/businessassistantbcn/opendata/controller/OpendataControllerTest.java
+++ b/BusinessAssistant-opendata/src/test/java/com/businessassistantbcn/opendata/controller/OpendataControllerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
@@ -35,7 +36,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
-@WebFluxTest(controllers = OpendataController.class)
+@WebFluxTest(controllers = OpendataController.class, excludeAutoConfiguration = {ReactiveSecurityAutoConfiguration.class})
 public class OpendataControllerTest {
 	
 	@Autowired


### PR DESCRIPTION
# OpenData
### Build.gradle: 
se añaden dependencias de seguridad 
- spring-boot-starter-security
- io.jsonwebtoken

### application.yml:
- se crean perfiles dev y pro
- se añaden security options

### se crean clases de configuración de seguridad replicando lo que ya está hecho en MyData:
- jwtFilter 
- HttpSecurityConfig
- SecurityPropertiesConfig

### ControllerTest:
- exclude AutoConfigReactive

## Hará falta esta anotación en el CommonController una vez que se integre la pull request que hay pendiente con la implementación del mismo (BABCN-77)