### PR TITLE
BUG004 - OpenData: BigMalls, CommercialGalleries & LargeEstablishments

### DIFF
--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/output/LargeEstablishmentsResponseDto.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/dto/output/LargeEstablishmentsResponseDto.java
@@ -1,0 +1,46 @@
+package com.businessassistantbcn.opendata.dto.output;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.businessassistantbcn.opendata.dto.ActivityInfoDto;
+import com.businessassistantbcn.opendata.dto.input.largeestablishments.AddressDto;
+import com.businessassistantbcn.opendata.dto.input.largeestablishments.ClassificationDataDto;
+import com.businessassistantbcn.opendata.dto.input.largeestablishments.ContactDto;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Component
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LargeEstablishmentsResponseDto {
+
+	private String name;
+	@JsonUnwrapped
+    private ContactDto value; // contact
+    private List<ActivityInfoDto> activities; // activities
+    private List<AddressDto> addresses;
+    
+    public List<ActivityInfoDto> mapClassificationDataListToActivityInfoList(List<ClassificationDataDto> classificationDataList) {
+		List<ActivityInfoDto> activities = new ArrayList<ActivityInfoDto>();
+
+		activities = classificationDataList.stream().map(c -> mapClassificationDataDtoToActivityInfoDto(c)).collect(Collectors.toList());
+		return activities;
+	}
+
+	public ActivityInfoDto mapClassificationDataDtoToActivityInfoDto(ClassificationDataDto classificationDataDto) {
+		ActivityInfoDto activity = new ActivityInfoDto();
+		activity.setActivityId(classificationDataDto.getId());
+		activity.setActivityName(classificationDataDto.getName());
+		
+		return activity;
+	}
+}

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/BigMallsService.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/BigMallsService.java
@@ -66,6 +66,7 @@ public class BigMallsService {
 	
 	private BigMallsResponseDto convertToDto(BigMallsDto bigMallsDto) {
 		BigMallsResponseDto responseDto = modelMapper.map(bigMallsDto, BigMallsResponseDto.class);
+		responseDto.setValue(bigMallsDto.getValues());
 		responseDto.setActivities(responseDto.mapClassificationDataListToActivityInfoList(bigMallsDto.getClassifications_data()));
 	    return responseDto;
 	}

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/CommercialGalleriesService.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/CommercialGalleriesService.java
@@ -53,7 +53,7 @@ public class CommercialGalleriesService {
 						.toArray(CommercialGalleriesDto[]::new);
 				CommercialGalleriesDto[] pagedDto = JsonHelper.filterDto(filteredDto, offset, limit);
 				
-				CommercialGalleriesResponseDto[] responseDto = Arrays.stream(pagedDto).map(p -> convertToDto(p)).toArray(CommercialGalleriesResponseDto[]::new);
+				CommercialGalleriesResponseDto[] responseDto = Arrays.stream(pagedDto).map(p -> convertToResponseDto(p)).toArray(CommercialGalleriesResponseDto[]::new);
 				
 				genericResultDto.setInfo(offset, limit, responseDto.length, responseDto);
 				return Mono.just(genericResultDto);
@@ -70,8 +70,9 @@ public class CommercialGalleriesService {
 		return commercialGalleriesDto;
 	}
 	
-	private CommercialGalleriesResponseDto convertToDto(CommercialGalleriesDto commercialGalleriesDto) {
+	private CommercialGalleriesResponseDto convertToResponseDto(CommercialGalleriesDto commercialGalleriesDto) {
 		CommercialGalleriesResponseDto responseDto = modelMapper.map(commercialGalleriesDto, CommercialGalleriesResponseDto.class);
+		responseDto.setValue(commercialGalleriesDto.getValues());		
 		responseDto.setActivities(responseDto.mapClassificationDataListToActivityInfoList(commercialGalleriesDto.getClassifications_data()));
 	    return responseDto;
 	}

--- a/BusinessAssistant-opendata/src/test/java/com/businessassistantbcn/opendata/service/externaldata/CommercialGalleriesServiceTest.java
+++ b/BusinessAssistant-opendata/src/test/java/com/businessassistantbcn/opendata/service/externaldata/CommercialGalleriesServiceTest.java
@@ -4,6 +4,7 @@ import com.businessassistantbcn.opendata.config.PropertiesConfig;
 import com.businessassistantbcn.opendata.dto.ActivityInfoDto;
 import com.businessassistantbcn.opendata.dto.GenericResultDto;
 import com.businessassistantbcn.opendata.dto.input.commercialgalleries.CommercialGalleriesDto;
+import com.businessassistantbcn.opendata.dto.output.CommercialGalleriesResponseDto;
 import com.businessassistantbcn.opendata.proxy.HttpProxy;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -50,6 +51,7 @@ public class CommercialGalleriesServiceTest {
 	private static final String JSON_FILENAME_COMERCIAL_GALLERIES_ACTIVITIES = "json/activitiesFromTwoComercialGalleriesForTesting.json";
 	private static ObjectMapper mapper;
 	private static CommercialGalleriesDto[] twoCommercialGalleriesDto;
+	private static CommercialGalleriesResponseDto[] responseDto;
 	private static ActivityInfoDto[] activities;
 	 
 	@BeforeAll
@@ -67,6 +69,20 @@ public class CommercialGalleriesServiceTest {
 		mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 		twoCommercialGalleriesDto = mapper.readValue(commercialGalleriesAsString, CommercialGalleriesDto[].class);
 		activities = mapper.readValue(commercialGalleriesActivitiesAsString, ActivityInfoDto[].class);
+		
+		responseDto = new CommercialGalleriesResponseDto[2];
+        CommercialGalleriesResponseDto responseDto1 = new CommercialGalleriesResponseDto();
+        responseDto1.setName(twoCommercialGalleriesDto[0].getName());
+        responseDto1.setValue(twoCommercialGalleriesDto[0].getValues());
+        responseDto1.setActivities(responseDto1.mapClassificationDataListToActivityInfoList(twoCommercialGalleriesDto[0].getClassifications_data()));
+        responseDto1.setAddresses(twoCommercialGalleriesDto[0].getAddresses());
+        responseDto[0] = responseDto1;
+        CommercialGalleriesResponseDto responseDto2 = new CommercialGalleriesResponseDto();
+        responseDto2.setName(twoCommercialGalleriesDto[1].getName());
+        responseDto2.setValue(twoCommercialGalleriesDto[1].getValues());
+        responseDto2.setActivities(responseDto2.mapClassificationDataListToActivityInfoList(twoCommercialGalleriesDto[1].getClassifications_data()));
+        responseDto2.setAddresses(twoCommercialGalleriesDto[1].getAddresses());
+        responseDto[1] =responseDto2;
 	}
 
 	@Test
@@ -75,10 +91,10 @@ public class CommercialGalleriesServiceTest {
 		when(httpProxy.getRequestData(any(URL.class), eq(CommercialGalleriesDto[].class)))
 			.thenReturn(Mono.just(twoCommercialGalleriesDto));
 
-		GenericResultDto<CommercialGalleriesDto> expectedResult = new GenericResultDto<CommercialGalleriesDto>();
-		expectedResult.setInfo(0, -1, twoCommercialGalleriesDto.length, twoCommercialGalleriesDto);
+		GenericResultDto<CommercialGalleriesResponseDto> expectedResult = new GenericResultDto<CommercialGalleriesResponseDto>();
+		expectedResult.setInfo(0, -1, twoCommercialGalleriesDto.length, responseDto);
 
-		GenericResultDto<CommercialGalleriesDto> actualResult =
+		GenericResultDto<CommercialGalleriesResponseDto> actualResult =
 			commercialGalleriesService.getPage(0, -1).block();
 		this.areOffsetLimitAndCountEqual(expectedResult, actualResult);
 		assertEquals(mapper.writeValueAsString(expectedResult.getResults()),
@@ -151,9 +167,9 @@ public class CommercialGalleriesServiceTest {
 		assertEquals(expected.getCount(), actual.getCount());
 	}
 
-	private void returnsCommercialGalleriesDefaultPage(GenericResultDto<CommercialGalleriesDto> actualResult) {
-		GenericResultDto<CommercialGalleriesDto> expectedResult = new GenericResultDto<CommercialGalleriesDto>();
-		expectedResult.setInfo(0, 0, 0, new CommercialGalleriesDto[0]);
+	private void returnsCommercialGalleriesDefaultPage(GenericResultDto<CommercialGalleriesResponseDto> actualResult) {
+		GenericResultDto<CommercialGalleriesResponseDto> expectedResult = new GenericResultDto<CommercialGalleriesResponseDto>();
+		expectedResult.setInfo(0, 0, 0, new CommercialGalleriesResponseDto[0]);
 
 		this.areOffsetLimitAndCountEqual(expectedResult, actualResult);
 		assertArrayEquals(expectedResult.getResults(), actualResult.getResults());

--- a/BusinessAssistant-opendata/src/test/java/com/businessassistantbcn/opendata/service/externaldata/LargeEstablishmentsServiceTest.java
+++ b/BusinessAssistant-opendata/src/test/java/com/businessassistantbcn/opendata/service/externaldata/LargeEstablishmentsServiceTest.java
@@ -4,6 +4,7 @@ import com.businessassistantbcn.opendata.config.PropertiesConfig;
 import com.businessassistantbcn.opendata.dto.ActivityInfoDto;
 import com.businessassistantbcn.opendata.dto.GenericResultDto;
 import com.businessassistantbcn.opendata.dto.input.largeestablishments.LargeEstablishmentsDto;
+import com.businessassistantbcn.opendata.dto.output.LargeEstablishmentsResponseDto;
 import com.businessassistantbcn.opendata.proxy.HttpProxy;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -54,6 +55,7 @@ public class LargeEstablishmentsServiceTest {
         "json/activitiesFromTwoLargeEstablishmentsForTesting.json";
     private static ObjectMapper mapper;
     private static LargeEstablishmentsDto[] twoLargeEstablishmentsDto;
+    private static LargeEstablishmentsResponseDto[] responseDto;
     private static ActivityInfoDto[] activities;
 
     @BeforeAll
@@ -77,6 +79,20 @@ public class LargeEstablishmentsServiceTest {
         mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         twoLargeEstablishmentsDto = mapper.readValue(largeEstablishmentsAsString, LargeEstablishmentsDto[].class);
         activities = mapper.readValue(largeEstablishmentsActivitiesAsString, ActivityInfoDto[].class);
+        
+        responseDto = new LargeEstablishmentsResponseDto[2];
+        LargeEstablishmentsResponseDto responseDto1 = new LargeEstablishmentsResponseDto();
+        responseDto1.setName(twoLargeEstablishmentsDto[0].getName());
+        responseDto1.setValue(twoLargeEstablishmentsDto[0].getValues());
+        responseDto1.setActivities(responseDto1.mapClassificationDataListToActivityInfoList(twoLargeEstablishmentsDto[0].getClassifications_data()));
+        responseDto1.setAddresses(twoLargeEstablishmentsDto[0].getAddresses());
+        responseDto[0] = responseDto1;
+        LargeEstablishmentsResponseDto responseDto2 = new LargeEstablishmentsResponseDto();
+        responseDto2.setName(twoLargeEstablishmentsDto[1].getName());
+        responseDto2.setValue(twoLargeEstablishmentsDto[1].getValues());
+        responseDto2.setActivities(responseDto2.mapClassificationDataListToActivityInfoList(twoLargeEstablishmentsDto[1].getClassifications_data()));
+        responseDto2.setAddresses(twoLargeEstablishmentsDto[1].getAddresses());
+        responseDto[1] =responseDto2;
     }
 
     @Test
@@ -85,7 +101,7 @@ public class LargeEstablishmentsServiceTest {
         when(httpProxy.getRequestData(any(URL.class), eq(LargeEstablishmentsDto[].class)))
             .thenReturn(Mono.just(twoLargeEstablishmentsDto));
 
-        GenericResultDto<LargeEstablishmentsDto> actualResult =
+        GenericResultDto<LargeEstablishmentsResponseDto> actualResult =
             largeEstablishmentsService.getPageByDistrict(0, -1, 5).block();
 
         assertEquals(0, actualResult.getOffset());
@@ -108,7 +124,7 @@ public class LargeEstablishmentsServiceTest {
         when(httpProxy.getRequestData(any(URL.class), eq(LargeEstablishmentsDto[].class)))
             .thenReturn(Mono.just(twoLargeEstablishmentsDto));
 
-        GenericResultDto<LargeEstablishmentsDto> actualResult =
+        GenericResultDto<LargeEstablishmentsResponseDto> actualResult =
             largeEstablishmentsService.getPageByActivity(0, -1, "1008031").block();
 
         assertEquals(0, actualResult.getOffset());
@@ -117,12 +133,12 @@ public class LargeEstablishmentsServiceTest {
         assertEquals(
             1008031,
             Arrays.stream(actualResult.getResults())
-                    .collect(Collectors.toList()).get(0).getClassifications_data().get(0).getId()
+                    .collect(Collectors.toList()).get(0).getActivities().get(0).getActivityId()
         );
         assertEquals(
             1008031,
             Arrays.stream(actualResult.getResults())
-                    .collect(Collectors.toList()).get(1).getClassifications_data().get(0).getId()
+                    .collect(Collectors.toList()).get(1).getActivities().get(0).getActivityId()
         );
 
         verify(config, times(1)).getDs_largeestablishments();
@@ -136,10 +152,10 @@ public class LargeEstablishmentsServiceTest {
         when(httpProxy.getRequestData(any(URL.class), eq(LargeEstablishmentsDto[].class)))
             .thenReturn(Mono.just(twoLargeEstablishmentsDto));
 
-        GenericResultDto<LargeEstablishmentsDto> expectedResult = new GenericResultDto<LargeEstablishmentsDto>();
-        expectedResult.setInfo(0, -1, twoLargeEstablishmentsDto.length, twoLargeEstablishmentsDto);
+        GenericResultDto<LargeEstablishmentsResponseDto> expectedResult = new GenericResultDto<LargeEstablishmentsResponseDto>();
+        expectedResult.setInfo(0, -1, twoLargeEstablishmentsDto.length, responseDto);
 
-        GenericResultDto<LargeEstablishmentsDto> actualResult =
+        GenericResultDto<LargeEstablishmentsResponseDto> actualResult =
             largeEstablishmentsService.getPage(0, -1).block();
         this.areOffsetLimitAndCountEqual(expectedResult, actualResult);
         assertEquals(mapper.writeValueAsString(expectedResult.getResults()),
@@ -215,9 +231,9 @@ public class LargeEstablishmentsServiceTest {
         assertEquals(expected.getCount(), actual.getCount());
     }
 
-    private void returnsLargeEstablishmentsDefaultPage(GenericResultDto<LargeEstablishmentsDto> actualResult) {
-        GenericResultDto<LargeEstablishmentsDto> expectedResult = new GenericResultDto<>();
-        expectedResult.setInfo(0, 0, 0, new LargeEstablishmentsDto[0]);
+    private void returnsLargeEstablishmentsDefaultPage(GenericResultDto<LargeEstablishmentsResponseDto> actualResult) {
+        GenericResultDto<LargeEstablishmentsResponseDto> expectedResult = new GenericResultDto<>();
+        expectedResult.setInfo(0, 0, 0, new LargeEstablishmentsResponseDto[0]);
 
         this.areOffsetLimitAndCountEqual(expectedResult, actualResult);
         assertArrayEquals(expectedResult.getResults(), actualResult.getResults());


### PR DESCRIPTION
### BigMalls, CommercialGalleries, LargeEstablishments:
- se crea LargeEstablishmentsResponseDto para elimiar full_path de la respuesta 
- se arreglan los fallos en los tests del service consecuencia del último refactor 

### MunicipalMarkets y MarketFairs:
- Ahora, se está utilizando @JsonIgnoreProperties en estos dos módulos y funcionan bien y no devuelven full_path.
- pero ahora funcionan porque no necesitan filtrar nada por full_path, en cuanto haga falta usar los campos ignorados volverán los bugs...

## Haré los cambios en MunicipalMarkets y MarketFairs igual que en el resto pero los subo en una pr separada por si acaso no hicieran falta porque no hay ningún bug que arreglar