### PR TITLE
 Replace de Slf4j #337

### DIFF
--- a/BusinessAssistant-login/src/main/java/com/businessassistantbcn/login/controller/LoginController.java
+++ b/BusinessAssistant-login/src/main/java/com/businessassistantbcn/login/controller/LoginController.java
@@ -4,18 +4,18 @@ import com.businessassistantbcn.login.dto.AuthenticationRequest;
 import com.businessassistantbcn.login.dto.AuthenticationResponse;
 import com.businessassistantbcn.login.service.LoginService;
 
-import lombok.extern.slf4j.Slf4j;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.*;
 
-@Slf4j
 @RestController
 @RequestMapping("/businessassistantbcn/api/v1")
 public class LoginController {
-	
+	private static final Logger log = LoggerFactory.getLogger(LoginController.class);
+
 	@Autowired
 	private LoginService loginService;
 	

--- a/BusinessAssistant-mydata/src/main/java/com/businessassistantbcn/mydata/service/UserSearchesService.java
+++ b/BusinessAssistant-mydata/src/main/java/com/businessassistantbcn/mydata/service/UserSearchesService.java
@@ -18,13 +18,14 @@ import com.businessassistantbcn.mydata.helper.JsonHelper;
 import com.businessassistantbcn.mydata.repository.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
-@Slf4j
 @Service
 public class UserSearchesService {
+	private static final Logger log = LoggerFactory.getLogger(UserSearchesService.class);
 	
 	@Autowired
 	UserSearchesRepository userSearchesRepo;

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/BigMallsService.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/BigMallsService.java
@@ -10,7 +10,8 @@ import com.businessassistantbcn.opendata.exception.OpendataUnavailableServiceExc
 import com.businessassistantbcn.opendata.helper.JsonHelper;
 import com.businessassistantbcn.opendata.proxy.HttpProxy;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,11 +25,11 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 public class BigMallsService {
 
-	//private static final Logger log = LoggerFactory.getLogger(BigMallsService.class);
+	private static final Logger log = LoggerFactory.getLogger(BigMallsService.class);
+
 	@Autowired
 	private PropertiesConfig config;
 	@Autowired

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/CommercialGalleriesService.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/CommercialGalleriesService.java
@@ -11,7 +11,8 @@ import com.businessassistantbcn.opendata.helper.JsonHelper;
 import com.businessassistantbcn.opendata.proxy.HttpProxy;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,11 +26,10 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 public class CommercialGalleriesService {
 
-	//private static final Logger log = LoggerFactory.getLogger(CommercialGalleriesService.class);
+	private static final Logger log = LoggerFactory.getLogger(CommercialGalleriesService.class);
 
 	@Autowired
 	private HttpProxy httpProxy;

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/EconomicActivitiesCensusService.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/EconomicActivitiesCensusService.java
@@ -7,19 +7,19 @@ import com.businessassistantbcn.opendata.exception.OpendataUnavailableServiceExc
 import com.businessassistantbcn.opendata.helper.JsonHelper;
 import com.businessassistantbcn.opendata.proxy.HttpProxy;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
-@Slf4j
 @Service
 public class EconomicActivitiesCensusService {
 
-	//private static final Logger log = LoggerFactory.getLogger(EconomicActivitiesCensusService.class);
+	private static final Logger log = LoggerFactory.getLogger(EconomicActivitiesCensusService.class);
 
 	@Autowired
 	private PropertiesConfig config;

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/LargeEstablishmentsService.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/LargeEstablishmentsService.java
@@ -9,10 +9,11 @@ import com.businessassistantbcn.opendata.exception.OpendataUnavailableServiceExc
 import com.businessassistantbcn.opendata.helper.JsonHelper;
 import com.businessassistantbcn.opendata.proxy.HttpProxy;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -22,10 +23,10 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 public class LargeEstablishmentsService {
-	
+	private static final Logger log = LoggerFactory.getLogger(LargeEstablishmentsService.class);
+
 	@Autowired
 	private HttpProxy httpProxy;
 	@Autowired

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/MarketFairsService.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/MarketFairsService.java
@@ -7,19 +7,19 @@ import com.businessassistantbcn.opendata.exception.OpendataUnavailableServiceExc
 import com.businessassistantbcn.opendata.helper.JsonHelper;
 import com.businessassistantbcn.opendata.proxy.HttpProxy;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
-@Slf4j
 @Service
 public class MarketFairsService {
 
-	//private static final Logger log = LoggerFactory.getLogger(MarketFairsService.class);
+	private static final Logger log = LoggerFactory.getLogger(MarketFairsService.class);
 
 	@Autowired
 	private PropertiesConfig config;

--- a/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/MunicipalMarketsService.java
+++ b/BusinessAssistant-opendata/src/main/java/com/businessassistantbcn/opendata/service/externaldata/MunicipalMarketsService.java
@@ -7,19 +7,19 @@ import com.businessassistantbcn.opendata.exception.OpendataUnavailableServiceExc
 import com.businessassistantbcn.opendata.helper.JsonHelper;
 import com.businessassistantbcn.opendata.proxy.HttpProxy;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
-@Slf4j
 @Service
 public class MunicipalMarketsService {
 
-	//private static final Logger log = LoggerFactory.getLogger(MunicipalMarketsService.class);
+	private static final Logger log = LoggerFactory.getLogger(MunicipalMarketsService.class);
 
 	@Autowired
 	private PropertiesConfig config;


### PR DESCRIPTION
#337 Replace de Slf4j: Es necesario asegurarse de que usamos sólo el logger añadido para nuestra aplicación, no el de ninguna biblioteca (para nuestro trazado).