### PR TITLE
#338 - Adicion de Swagger a Login

### DIFF
--- a/BusinessAssistant-login/build.gradle
+++ b/BusinessAssistant-login/build.gradle
@@ -24,6 +24,12 @@ dependencies {
     // JAX-B dependencies for JDK 9+
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2'
 
+    //dependencies for Swagger
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.8'
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-data-rest', version: '1.6.8'
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-security', version: '1.6.8'
+
+
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2', 'io.jsonwebtoken:jjwt-jackson:0.11.2'
     

--- a/BusinessAssistant-login/src/main/java/com/businessassistantbcn/login/config/WebSecurityConfig.java
+++ b/BusinessAssistant-login/src/main/java/com/businessassistantbcn/login/config/WebSecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -46,7 +47,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		http.authorizeRequests().antMatchers(HttpMethod.POST, config.getSignUpUrl()).permitAll();
 		http.authorizeRequests().anyRequest().authenticated();
 		http.exceptionHandling().authenticationEntryPoint(new BasicAuthenticationEntryPoint() {
-			
+
 			@Override
 			public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
 				response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
@@ -54,6 +55,15 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 			}
 			
 		});
+	}
+
+	@Override
+	public void configure(WebSecurity web){
+		web.ignoring()
+				.antMatchers("/swagger-ui/**",
+						"/swagger-ui-custom.html",
+						"/api-docs/**")
+				.anyRequest();
 	}
 	
 }

--- a/BusinessAssistant-login/src/main/resources/application.yml
+++ b/BusinessAssistant-login/src/main/resources/application.yml
@@ -4,6 +4,14 @@ spring:
   jmx:
     enabled: true
 
+springdoc:
+  swagger-ui:
+    path: "/swagger-ui-custom.html"
+    operationsSorted: method
+  api-docs:
+    enable: true
+    path: "/api-docs"
+
 server:
   port: 8761
 


### PR DESCRIPTION
url's
http://localhost:8761/swagger-ui-custom.html
http://localhost:8761/api-docs

Notas:
1. En la clase WebSecurityConfig se implemento el método configure(WebSecurity) para ignorar la seguridad en las url's con los patrones de swagger (/swagger-ui/**, /swagger-ui-custom.html, /api-docs/**)
2. Al probar el controller de login (businessassistantbcn/api/v1/login), en la interfaz grafica de swagger (try it out), si se proporcionan las credenciales que se encuentran el el readme del microservicio de login simula la respuesta del servidor status ok