### PR TITLE
Endpoints Gencat

### DIFF
--- a/BusinessAssistant-gencat/src/main/java/com/businessassistantbcn/gencat/config/PropertiesConfig.java
+++ b/BusinessAssistant-gencat/src/main/java/com/businessassistantbcn/gencat/config/PropertiesConfig.java
@@ -13,6 +13,8 @@ public class PropertiesConfig {
     private String ds_test;
     private Integer maxBytesInMemory;
 
+    private String ds_economicActivities;
+
     public int getMaxBytesInMemory() {
         return maxBytesInMemory;
     }
@@ -35,5 +37,13 @@ public class PropertiesConfig {
 
     public void setDs_test(String ds_test) {
         this.ds_test = ds_test;
+    }
+
+    public String getDs_economicActivities() {
+        return ds_economicActivities;
+    }
+
+    public void setDs_economicActivities(String ds_economicActivities) {
+        this.ds_economicActivities = ds_economicActivities;
     }
 }

--- a/BusinessAssistant-gencat/src/main/java/com/businessassistantbcn/gencat/controller/GencatController.java
+++ b/BusinessAssistant-gencat/src/main/java/com/businessassistantbcn/gencat/controller/GencatController.java
@@ -1,10 +1,18 @@
 package com.businessassistantbcn.gencat.controller;
 
+import com.businessassistantbcn.gencat.config.PropertiesConfig;
+import com.businessassistantbcn.gencat.proxy.HttpProxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
 
 @RestController
 @RequestMapping(value = "/businessassistantbcn/api/v1/gencat")
@@ -12,9 +20,47 @@ public class GencatController {
 
     private static final Logger log = LoggerFactory.getLogger(GencatController.class);
 
-    @GetMapping(value="/test")
+    @Autowired
+    private HttpProxy httpProxy;
+
+    @Autowired
+    private PropertiesConfig config;
+
+    private URL url;
+
+    @GetMapping(value = "/test")
     public String test() {
         log.info("** Saludos desde el logger **");
         return "Hello from GenCat Controller!!!";
     }
+
+    //se debe implementar cuando se hayan definido los dto y service layer
+    @GetMapping("/ccae")
+    public Mono<List<Object>> getAllClassificationOfEconomicActivities() throws MalformedURLException {
+        url = new URL(config.getDs_economicActivities());
+        Object[] economicActivities = httpProxy.getRequestData(url, Object[].class).block();
+        return Mono.just((Arrays.asList(economicActivities)));
+    }
+
+    //se debe implementar
+    @GetMapping("/ccae/{ccae_id}")
+    @ResponseStatus(HttpStatus.NOT_IMPLEMENTED)
+    public Mono getEconomicActivityById(@PathVariable("ccae_id") String ccaeId) {
+        return Mono.just(HttpStatus.NOT_IMPLEMENTED);
+    }
+
+    //se debe implementar
+    @GetMapping("/ccae/type/{type}")
+    @ResponseStatus(HttpStatus.NOT_IMPLEMENTED)
+    public Mono getEconomicActivityByType(@PathVariable("type") String type) {
+        return Mono.just(HttpStatus.NOT_IMPLEMENTED);
+    }
+
+    //se debe implementar
+    @GetMapping("/ccae/types")
+    @ResponseStatus(HttpStatus.NOT_IMPLEMENTED)
+    public Mono getEconomicActivitiesTypes() {
+        return Mono.just(HttpStatus.NOT_IMPLEMENTED);
+    }
+
 }

--- a/BusinessAssistant-gencat/src/main/resources/application.yml
+++ b/BusinessAssistant-gencat/src/main/resources/application.yml
@@ -44,6 +44,7 @@ url:
   connection_timeout: 30000
   maxBytesInMemory: 30000000
   ds_test: https://swapi.py4e.com/api/vehicles/
+  ds_economicActivities: https://analisi.transparenciacatalunya.cat/resource/get5-imi7.json
 
 
 logging:

--- a/BusinessAssistant-gencat/src/test/java/com/businessassistantbcn/gencat/controller/GencatControllerTest.java
+++ b/BusinessAssistant-gencat/src/test/java/com/businessassistantbcn/gencat/controller/GencatControllerTest.java
@@ -1,15 +1,26 @@
 package com.businessassistantbcn.gencat.controller;
 
+import com.businessassistantbcn.gencat.config.PropertiesConfig;
+import com.businessassistantbcn.gencat.proxy.HttpProxy;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+import java.io.*;
+import java.net.URL;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @WebFluxTest(controllers = GencatController.class, excludeAutoConfiguration = {ReactiveSecurityAutoConfiguration.class})
@@ -18,13 +29,25 @@ class GencatControllerTest {
     @Autowired
     private WebTestClient webTestClient;
 
+    @MockBean
+    @Autowired
+    private HttpProxy httpProxy;
+
+    @MockBean
+    @Autowired
+    private PropertiesConfig config;
+
     private final String CONTROLLER_BASE_URL = "/businessassistantbcn/api/v1/gencat";
+
+    @Autowired
+    private GencatController gencatController;
+
+    private URL url;
+    private Object[] economicActivities;
 
     @Test
     void testHello() {
-
         final String URI_TEST = "/test";
-
         webTestClient.get()
                 .uri(CONTROLLER_BASE_URL + URI_TEST)
                 .accept(MediaType.APPLICATION_JSON)
@@ -33,4 +56,50 @@ class GencatControllerTest {
                 .expectBody(String.class)
                 .value(s -> s.toString(), equalTo("Hello from GenCat Controller!!!"));
     }
+
+    //Una vez implementado correctamente el método, el test se debe adecuar
+    @Test
+    void getAllEconomicActivities() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        url = new URL("https://analisi.transparenciacatalunya.cat/resource/get5-imi7.json");
+        economicActivities = mapper.readValue(url, Object[].class);
+        when(config.getDs_economicActivities()).thenReturn(url.toString());
+        when(httpProxy.getRequestData(url, Object[].class)).thenReturn(Mono.just(economicActivities));
+        assertNotNull(gencatController.getAllClassificationOfEconomicActivities());
+    }
+
+    //Una vez implementado correctamente el método, el test se debe adecuar
+    @Test
+    void getEconomicActivityById() {
+        final String URI_TEST = "/ccae/1";
+        webTestClient.get()
+                .uri(CONTROLLER_BASE_URL + URI_TEST)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+    }
+
+    //Una vez implementado correctamente el método, el test se debe adecuar
+    @Test
+    void getEconomicActivityType() {
+        final String URI_TEST = "/ccae/type/1";
+        webTestClient.get()
+                .uri(CONTROLLER_BASE_URL + URI_TEST)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+    }
+
+    //Una vez implementado correctamente el método, el test se debe adecuar
+    @Test
+    void getEconomicActivitiesTypes() {
+        final String URI_TEST = "/ccae/types";
+        webTestClient.get()
+                .uri(CONTROLLER_BASE_URL + URI_TEST)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+
+    }
+
 }


### PR DESCRIPTION
- Se crearon los endpoints solicitados, los cuales se deben implementar adecuadamente una vez se creen los DTO's y la service layer.
- Se añadió al application.yml la url --> https://analisi.transparenciacatalunya.cat/resource/get5-imi7.json, de donde se obtiene la data.
- Se realizaron test de los endpoints, comprobando la correcta obtención de la data requerida. 
- En la tarea: Creación de endpoint GET para obtención de CCAE filtrado por type (/businessassistantbcn/api/v1/gencat/ccae/{type}), se tuvo que cambiar el endpoint ya que generaba una exception de ambigüedad con el endpoint de filtrado por id, (resultado: /businessassistantbcn/api/v1/gencat/ccae/type/{type})